### PR TITLE
Fix for millis() rollover when computing time interval.  My first zen project commit from vscode/pio.

### DIFF
--- a/bgeigiezen_firmware/gfx_screen.cpp
+++ b/bgeigiezen_firmware/gfx_screen.cpp
@@ -123,7 +123,7 @@ void GFXScreen::handle_report(const worker_map_t& workers, const handler_map_t& 
       }
     }
 
-    if (workers.any_updates() || handlers.any_updates() || _last_render + 1000 < millis()) {
+    if (workers.any_updates() || handlers.any_updates() || (millis() - _last_render > 1000)) {
       M5.Lcd.setRotation(3);
       if (_menu->is_open()) {
         _menu->do_render(workers, handlers);

--- a/bgeigiezen_firmware/screens/boot_screen.cpp
+++ b/bgeigiezen_firmware/screens/boot_screen.cpp
@@ -9,7 +9,7 @@ BootScreen::BootScreen() : BaseScreen("Boot", false), _entered_at(0) {
 }
 
 BaseScreen* BootScreen::handle_input(Controller& controller, const worker_map_t& workers) {
-  if (_entered_at + 3000 < millis()) {
+  if (millis() - _entered_at > 3000) {
     if (controller.get_data().sd_card_status != SDInterface::SdStatus::e_sd_config_status_ok) {
       return SdMessageScreen::i();
     }

--- a/bgeigiezen_firmware/utils/sd_wrapper.cpp
+++ b/bgeigiezen_firmware/utils/sd_wrapper.cpp
@@ -63,7 +63,9 @@ bool SDInterface::ready() {
  * @return true if ready
  */
 bool SDInterface::begin() {
-  if (!_sd_ready && (_last_try == 0 || _last_try + 5000 < millis())) {
+  static bool _first_try = true;
+  if (!_sd_ready && (_first_try || (millis() - _last_try > 5000))) {
+    _first_try = false;
     _last_try = millis();
     if (SD.begin(SD_CS_PIN)) {
       bool zen_test = SD.exists(TEST_FILENAME);

--- a/bgeigiezen_firmware/workers/gps_connector.cpp
+++ b/bgeigiezen_firmware/workers/gps_connector.cpp
@@ -28,7 +28,7 @@ bool GpsConnector::activate(bool retry) {
     ss.begin(38400);
     _init_at = millis();
   }
-  if (tried_38400_at == 0 && millis() > _init_at + 500) { // Wait for device to completely startup
+  if (tried_38400_at == 0 && (millis() - _init_at > 500)) { // Wait for device to completely startup
     tried_38400_at = millis();
     ss.updateBaudRate(38400);
     DEBUG_PRINTF("GNSS: trying 38400 baud at millis %d\n", tried_38400_at);
@@ -39,7 +39,7 @@ bool GpsConnector::activate(bool retry) {
       return false;
     }
   }
-  else if (tried_9600_at == 0 && tried_38400_at > 0 && millis() - tried_38400_at > 500) {
+  else if (tried_9600_at == 0 && tried_38400_at > 0 && (millis() - tried_38400_at > 500)) {
     tried_9600_at = millis();
     ss.updateBaudRate(9600);
     DEBUG_PRINTF("GNSS: trying 9600 baud at millis %d\n", tried_9600_at);


### PR DESCRIPTION
Simple fix to compare time-intervals instead of comparing time-values to avoid millis() rollover issues which happens every 49.7 days. I know this fix is really not needed for start-up code (when millis() is initialized) but it's nice to be consistent.