### PR TITLE
fix: improve GPS lock feedback and accept first UBX fix

### DIFF
--- a/bgeigiezen_firmware/main.cpp
+++ b/bgeigiezen_firmware/main.cpp
@@ -78,7 +78,7 @@ ZenButton zen_C(M5.BtnC);
 GpsConnector gps(gnss, Serial2);
 // Make GPS connector globally available for shutdown routine
 GpsConnector* g_active_gps = &gps;
-NavsatCollector navsat(gnss, gps.get_data());
+NavsatCollector navsat(gnss, gps);
 GeigerCounter gm_sensor;
 BatteryIndicator battery_indicator;
 DateTimeProvider rtc;

--- a/bgeigiezen_firmware/workers/gps_connector.cpp
+++ b/bgeigiezen_firmware/workers/gps_connector.cpp
@@ -735,6 +735,9 @@ int8_t GpsConnector::produce_data() {
     if (_gnss.getFixType() == 2 || _gnss.getFixType() == 3) {
       // M5_LOGD("[%d] fix type is 2D or 3D.", millis());
       data.pdop = _gnss.getPDOP() * 1e-2; // Position Dilution of Precision
+      // Bypass distance gate on the very first fix; otherwise haversine() to
+      // (0,0) is huge and the first valid sample would be discarded.
+      const bool first_fix = (_last_latitude == 0.0 && _last_longitude == 0.0);
       _last_latitude = data.latitude;
       _last_longitude = data.longitude;
       data.latitude = _gnss.getLatitude() * 1e-7;
@@ -779,7 +782,7 @@ int8_t GpsConnector::produce_data() {
       data.sAcc = _gnss.getSpeedAccEst();
       data.headAcc = _gnss.getHeadingAccEst();
 
-      data.location_valid = _gnss.getGnssFixOk() && distance_step < 0.5; // Airplanes fly at 255m per second, 500 meter check is good enough
+      data.location_valid = _gnss.getGnssFixOk() && (first_fix || distance_step < 0.5); // Airplanes fly at 255m per second, 500 meter check is good enough
       location_timer.restart();
       ret_status = e_worker_data_read;
       // DEBUG: Compare PDOP from NAV-PVT and HDOP from NAV-DOP

--- a/bgeigiezen_firmware/workers/gps_connector.h
+++ b/bgeigiezen_firmware/workers/gps_connector.h
@@ -203,6 +203,10 @@ class GpsConnector : public Worker<GnssData> {
    */
   void calculateChecksum(const uint8_t* data, size_t len, uint8_t* cka, uint8_t* ckb);
 
+  // Allow NavsatCollector (UBX mode) to publish the visible-sat count back into
+  // GnssData so the status bar can show "tracking but no fix yet" before fix.
+  void set_visible_sats(uint8_t n) { data.numSV = n; }
+
  protected:
   void deactivate() override;
 

--- a/bgeigiezen_firmware/workers/navsat_collector.cpp
+++ b/bgeigiezen_firmware/workers/navsat_collector.cpp
@@ -1,10 +1,10 @@
 #include "navsat_collector.h"
 
 
-NavsatCollector::NavsatCollector(TeenyUbloxConnect& gnss, const GnssData& gps_data) : Worker<NavsatData>({
+NavsatCollector::NavsatCollector(TeenyUbloxConnect& gnss, GpsConnector& gps) : Worker<NavsatData>({
                                                                 .available=false,
                                                                 .navsat_info=ubloxNAVSATInfo_t(),
-                                                            }), _gnss(gnss), _gps_data(gps_data), _last_gsv_cycle(0) {
+                                                            }), _gnss(gnss), _gps(gps), _gps_data(gps.get_data()), _last_gsv_cycle(0) {
 }
 
 /**
@@ -61,6 +61,12 @@ int8_t NavsatCollector::produce_data() {
   if (_gnss.getNAVSAT()) {
     _gnss.getNAVSATInfo(data.navsat_info);
     data.available = data.navsat_info.validPacket;
+    // Surface the visible-sat count to GnssData so the status bar can show
+    // "tracking but no fix yet" before a fix is acquired (NAV-PVT.numSV is
+    // sats-used-in-fix only, so it stays 0 during cold-start tracking).
+    if (data.available) {
+      _gps.set_visible_sats(data.navsat_info.numSvs);
+    }
     return e_worker_data_read;
   }
   return e_worker_idle;

--- a/bgeigiezen_firmware/workers/navsat_collector.h
+++ b/bgeigiezen_firmware/workers/navsat_collector.h
@@ -19,7 +19,7 @@ struct NavsatData {
 class NavsatCollector : public Worker<NavsatData> {
  public:
 
-  explicit NavsatCollector(TeenyUbloxConnect& _gnss, const GnssData& gps_data);
+  explicit NavsatCollector(TeenyUbloxConnect& _gnss, GpsConnector& gps);
 
   virtual ~NavsatCollector() = default;
 
@@ -31,6 +31,7 @@ class NavsatCollector : public Worker<NavsatData> {
 
  private:
   TeenyUbloxConnect& _gnss;
+  GpsConnector& _gps;
   const GnssData& _gps_data;
   uint32_t _last_gsv_cycle;
 };


### PR DESCRIPTION
Follow-up to #84 (Codeberg #6). Audited the GPS path for similar issues; these two had the highest user-visible impact for M8/M10.

## Summary
**Fix #2 — Visible-sat count in UBX mode.** NAV-PVT.numSV is sats-used-in-fix only, so on M8/M10 `GnssData.numSV` stayed 0 during cold-start tracking. The status bar's "GPS12 orange (tracking, no fix yet)" intermediate stage in [gfx_screen.cpp:411](bgeigiezen_firmware/gfx_screen.cpp#L411) never triggered; users jumped from "GPS?" straight to "GPS5 green" with no feedback during acquisition. `NavsatCollector` already polls NAV-SAT (which has the visible count), so it now publishes that count back into `GnssData` via a new `GpsConnector::set_visible_sats()` helper. NMEA mode was already setting `data.numSV` from `$GPGSV`, so M7 is unaffected.

**Fix #3 — Accept the first valid UBX fix.** The distance-sanity gate (`distance_step < 0.5 km`) rejected the first fix because `_last_latitude`/`_last_longitude` were 0 and `haversine()` to real coordinates produced a multi-thousand-km distance. NMEA mode had a `first_fix` bypass; UBX did not. Cost: ~1 s of TTFF and one wasted sample on every cold start.

## Test plan
- [x] Builds cleanly for `m5stack-cores3-unified` (RAM 36.8% / Flash 29.5%, +8 B RAM / +68 B flash, no new warnings)
- [ ] Field test on M7 — confirm no regression (NMEA path unchanged)
- [ ] Field test on M8 — confirm "GPS12 orange" stage appears during cold-start search
- [ ] Field test on M10 — confirm "GPS12 orange" stage appears during cold-start search
- [ ] Confirm first valid UBX fix is now accepted (compare TTFF with prior firmware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)