### PR TITLE
Fix tooltip word-wrap and menu sentinel for remaining submenus

### DIFF
--- a/bgeigiezen_firmware/screens/base_screen.cpp
+++ b/bgeigiezen_firmware/screens/base_screen.cpp
@@ -293,18 +293,73 @@ void BaseScreenWithMenu::render_menu(const MenuItem items[], int menu_max, bool 
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
   M5.Lcd.setCursor(170, 46);
   M5.Lcd.println(items[_menu_index].title);
-  size_t tooltip_length = strlen(items[_menu_index].tooltip);
+  // Word-wrap the tooltip on whitespace so words never break mid-character.
+  // The tooltip area is ~124 px wide starting at x=170; each line is 16 px tall.
+  const char* tooltip = items[_menu_index].tooltip;
+  size_t tooltip_length = strlen(tooltip);
   uint8_t line = 0;
   uint8_t current_line_length = 0;
-  M5.Lcd.setCursor(170, 76);
-  for (size_t i = 0; i < tooltip_length; ++i) {
-    if (current_line_length == 0 && items[_menu_index].tooltip[i] == ' ') {
+  size_t i = 0;
+  while (i < tooltip_length) {
+    // Skip whitespace at the start of a line
+    if (current_line_length == 0 && (tooltip[i] == ' ' || tooltip[i] == '\n')) {
+      ++i;
       continue;
     }
-    current_line_length += M5.Lcd.drawChar(items[_menu_index].tooltip[i], 170 + current_line_length, 76 + (line * 16), 2);
-    if (current_line_length > 124) {
+    // Honour explicit newlines
+    if (tooltip[i] == '\n') {
       line += 1;
       current_line_length = 0;
+      ++i;
+      continue;
+    }
+    // Find the end of the next word (run of non-space chars)
+    size_t word_end = i;
+    while (word_end < tooltip_length && tooltip[word_end] != ' ' && tooltip[word_end] != '\n') {
+      ++word_end;
+    }
+    // Measure the word
+    char word_buf[40];
+    size_t word_len = word_end - i;
+    if (word_len >= sizeof(word_buf)) word_len = sizeof(word_buf) - 1;
+    memcpy(word_buf, tooltip + i, word_len);
+    word_buf[word_len] = '\0';
+    int32_t word_width = M5.Lcd.textWidth(word_buf, &fonts::Font2);
+    // Wrap if the word doesn't fit on the current line (and we've already drawn something)
+    if (current_line_length > 0 && current_line_length + word_width > 124) {
+      line += 1;
+      current_line_length = 0;
+      continue;  // re-evaluate the same word at line start
+    }
+    // Draw the word char by char (drawChar returns advance width)
+    for (size_t j = 0; j < word_len; ++j) {
+      current_line_length += M5.Lcd.drawChar(word_buf[j], 170 + current_line_length, 76 + (line * 16), 2);
+    }
+    i = word_end;
+    // Consume a single trailing space; emit it only if the next word fits
+    if (i < tooltip_length && tooltip[i] == ' ') {
+      // Look ahead at next word width to decide whether to draw the space
+      size_t next_start = i + 1;
+      size_t next_end = next_start;
+      while (next_end < tooltip_length && tooltip[next_end] != ' ' && tooltip[next_end] != '\n') {
+        ++next_end;
+      }
+      char next_buf[40];
+      size_t next_len = next_end - next_start;
+      if (next_len >= sizeof(next_buf)) next_len = sizeof(next_buf) - 1;
+      memcpy(next_buf, tooltip + next_start, next_len);
+      next_buf[next_len] = '\0';
+      int32_t next_width = next_len > 0 ? M5.Lcd.textWidth(next_buf, &fonts::Font2) : 0;
+      int32_t space_width = M5.Lcd.textWidth(" ", &fonts::Font2);
+      if (current_line_length + space_width + next_width <= 124) {
+        current_line_length += M5.Lcd.drawChar(' ', 170 + current_line_length, 76 + (line * 16), 2);
+        ++i;
+      } else {
+        // Drop the space and wrap
+        line += 1;
+        current_line_length = 0;
+        ++i;
+      }
     }
   }
   if (!items[_menu_index].enabled) {

--- a/bgeigiezen_firmware/screens/sd_settings.cpp
+++ b/bgeigiezen_firmware/screens/sd_settings.cpp
@@ -17,6 +17,7 @@ static const SdSettingsScreen::MenuItem SD_MENU[SdSettingsScreen::e_sd_MENU_MAX]
 };
 
 SdSettingsScreen::SdSettingsScreen() : BaseScreenWithMenu("SD card", true) {
+  _current_page = e_sd_MENU_MAX;  // sentinel: "show menu, no action page"
 }
 
 void SdSettingsScreen::enter_screen(Controller& controller) {
@@ -27,31 +28,35 @@ void SdSettingsScreen::enter_screen(Controller& controller) {
       } else {
         set_status_message(F(" LOAD CONFIG FAILED, no config or SD-card! "));
       }
-      _current_page = e_sd_page_load_config;
+      // Action complete — bounce back to the submenu
+      _current_page = e_sd_MENU_MAX;
       _menu_index = e_sd_page_load_config;
       open_menu(true);
-      force_next_render();
-      return;
+      break;
     case e_sd_page_save_config:
       if (controller.write_sd_config()) {
         set_status_message(F(" CONFIG SAVED, settings have been saved to SD! "));
       } else {
         set_status_message(F(" WRITE CONFIG FAILED, no SD-card! "));
       }
-      _current_page = e_sd_page_save_config;
+      _current_page = e_sd_MENU_MAX;
       _menu_index = e_sd_page_save_config;
       open_menu(true);
-      force_next_render();
-      return;
+      break;
+    case e_sd_MENU_MAX:
+      // External entry — open the submenu
+      _menu_index = 0;
+      open_menu(true);
+      break;
     default:
+      // Page swap to wipe — render() will show that page
       break;
   }
-
-  // Default entry: open submenu
-  _current_page = e_sd_page_load_config;
-  _menu_index = 0;
-  open_menu(true);
   force_next_render();
+}
+
+void SdSettingsScreen::leave_screen(Controller& controller) {
+  _current_page = e_sd_MENU_MAX;
 }
 
 BaseScreen* SdSettingsScreen::handle_input(Controller& controller, const worker_map_t& workers) {

--- a/bgeigiezen_firmware/screens/sd_settings.h
+++ b/bgeigiezen_firmware/screens/sd_settings.h
@@ -17,6 +17,7 @@ class SdSettingsScreen : public BaseScreenWithMenu {
 
   BaseScreen* handle_input(Controller& controller, const worker_map_t& workers) override;
   void enter_screen(Controller& controller) override;
+  void leave_screen(Controller& controller) override;
 
  protected:
   void render(const worker_map_t& workers, const handler_map_t& handlers, bool force) override;

--- a/bgeigiezen_firmware/screens/sound_settings.cpp
+++ b/bgeigiezen_firmware/screens/sound_settings.cpp
@@ -16,14 +16,21 @@ static const SoundSettingsScreen::MenuItem SOUND_MENU[SoundSettingsScreen::e_sou
 };
 
 SoundSettingsScreen::SoundSettingsScreen() : BaseScreenWithMenu("Sound", true), _audio_field(0) {
+  _current_page = e_sound_MENU_MAX;  // sentinel: "show menu, no action page"
 }
 
 void SoundSettingsScreen::enter_screen(Controller& controller) {
-  _current_page = e_sound_page_audio;
-  _menu_index = 0;
-  _audio_field = 0;
-  open_menu(true);
+  if (_current_page == e_sound_MENU_MAX) {
+    _menu_index = 0;
+    _audio_field = 0;
+    open_menu(true);
+  }
+  // else: handle_menu_input did an internal page-swap; render() shows the page
   force_next_render();
+}
+
+void SoundSettingsScreen::leave_screen(Controller& controller) {
+  _current_page = e_sound_MENU_MAX;
 }
 
 BaseScreen* SoundSettingsScreen::handle_input(Controller& controller, const worker_map_t& workers) {

--- a/bgeigiezen_firmware/screens/sound_settings.h
+++ b/bgeigiezen_firmware/screens/sound_settings.h
@@ -16,6 +16,7 @@ class SoundSettingsScreen : public BaseScreenWithMenu {
 
   BaseScreen* handle_input(Controller& controller, const worker_map_t& workers) override;
   void enter_screen(Controller& controller) override;
+  void leave_screen(Controller& controller) override;
 
  protected:
   void render(const worker_map_t& workers, const handler_map_t& handlers, bool force) override;

--- a/bgeigiezen_firmware/screens/wifi_settings.cpp
+++ b/bgeigiezen_firmware/screens/wifi_settings.cpp
@@ -18,6 +18,7 @@ static const WifiSettingsScreen::MenuItem WIFI_MENU[WifiSettingsScreen::e_wifi_M
 };
 
 WifiSettingsScreen::WifiSettingsScreen() : BaseScreenWithMenu("WiFi", true) {
+  _current_page = e_wifi_MENU_MAX;  // sentinel: "show menu, no action page"
 }
 
 void WifiSettingsScreen::enter_screen(Controller& controller) {
@@ -27,20 +28,17 @@ void WifiSettingsScreen::enter_screen(Controller& controller) {
     case e_wifi_page_ap:
       WiFiWrapper_i.start_ap_server(controller.get_settings().get_device_id(), controller.get_settings().get_ap_password());
       controller.set_worker_active(k_worker_config_server, true);
-      force_next_render();
-      return;
+      break;
     case e_wifi_page_local:
       WiFiWrapper_i.connect_wifi(controller.get_settings().get_wifi_ssid(), controller.get_settings().get_wifi_password());
       controller.set_worker_active(k_worker_config_server, true);
-      force_next_render();
-      return;
+      break;
     default:
+      // Sentinel or other — open the submenu
+      _menu_index = 0;
+      open_menu(true);
       break;
   }
-
-  _current_page = e_wifi_page_ap;
-  _menu_index = 0;
-  open_menu(true);
   force_next_render();
 }
 
@@ -57,7 +55,7 @@ void WifiSettingsScreen::leave_screen(Controller& controller) {
     default:
       break;
   }
-  _current_page = e_wifi_page_ap;
+  _current_page = e_wifi_MENU_MAX;
 }
 
 BaseScreen* WifiSettingsScreen::handle_input(Controller& controller, const worker_map_t& workers) {


### PR DESCRIPTION
## Summary

- **Word-wrap tooltips.** [base_screen.cpp:296-358](bgeigiezen_firmware/screens/base_screen.cpp#L296-L358) — the menu tooltip renderer wrapped on character boundaries, so words broke mid-letter once we removed the manual padding from tooltip strings. Replaced with a word-aware loop that measures each word via \`M5.Lcd.textWidth\` and honours explicit \`\\n\` as a forced break.
- **Sentinel pattern for the multi-page submenus.** Sound, WiFi, and SD-card submenus now use \`e_X_MENU_MAX\` as a "show menu, no action page" sentinel. \`enter_screen\` checks for it before opening the menu; \`leave_screen\` resets to it. This fixes:
  - **Sound:** "CPM alert" used to bounce back to Audio.
  - **WiFi:** AP/local-network start was re-triggered on every external entry to the WiFi submenu.
  - **SD card:** the first entry to the SD-card submenu silently auto-loaded the SD config.
  - (The same bug for *About this device → Debug info* in Utilities was already fixed in the prior commit.)

## Test plan

- [ ] Open Settings → Sound → CPM alert level: cursor lands on the CPM page (not Audio).
- [ ] Open Settings → WiFi: AP server is **not** started until you select "Start Access Point".
- [ ] Open Settings → SD card on a fresh boot: nothing happens automatically; "Load from SD" must be chosen explicitly.
- [ ] Open Settings → Utilities → About this device: cursor stays on "About this device" / opens the info page.
- [ ] Visually inspect tooltip text for any submenu — words wrap on whitespace, no mid-word breaks.

## Build

\`pio run -e m5stack-cores3-unified\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)