### PR TITLE
v3.4.1: SD log upload + log viewer UX polish

### DIFF
--- a/bgeigiezen_firmware/handlers/sd_logger.cpp
+++ b/bgeigiezen_firmware/handlers/sd_logger.cpp
@@ -152,7 +152,7 @@ const char* SdLogger::get_dir() const {
     case survey:
       return SURVEY_LOG_DIRECTORY;
     case flight:
-      return "/flight"; // Directory for flight logs
+      return FLIGHT_LOG_DIRECTORY;
     default:
       return "unknown";
   }

--- a/bgeigiezen_firmware/screens/log_viewer.cpp
+++ b/bgeigiezen_firmware/screens/log_viewer.cpp
@@ -1,8 +1,12 @@
 #include <HTTPClient.h>
+#include <WiFiClientSecure.h>
+#include <SD.h>
 
 #include "log_viewer.h"
 #include "identifiers.h"
 #include "menu_window.h"
+#include "user_config.h"
+#include "utils/sd_wrapper.h"
 #include "workers/local_storage.h"
 #include "workers/zen_button.h"
 #include "utils/wifi_connection.h"
@@ -36,9 +40,67 @@ LogViewerScreen::LogViewerScreen() : BaseScreen("Log view", true),
                                      _detail_log_file_name(""),
                                      _detail_log_timestamp{},
                                      _detail_upload_timestamp{},
-                                     _detail_log_upload_id(0) {
+                                     _detail_log_upload_id(0),
+                                     _file_count(0),
+                                     _selected_index(0),
+                                     _main_selected_index(0),
+                                     _upload_status(e_upload_idle),
+                                     _upload_http_code(0) {
   required_wifi = true;
   required_sd = true;
+  _file_list[0][0] = '\0';
+}
+
+const char* LogViewerScreen::current_dir() const {
+  switch (_current_view) {
+    case e_log_drive_view:   return DRIVE_LOG_DIRECTORY;
+    case e_log_survey_view:  return SURVEY_LOG_DIRECTORY;
+    case e_log_journal_view: return JOURNAL_LOG_DIRECTORY;
+    default:                 return nullptr;
+  }
+}
+
+void LogViewerScreen::load_log_list(const char* dir) {
+  _file_count = 0;
+  _selected_index = 0;
+  if (!dir) return;
+
+  File root = SD.open(dir, FILE_READ);
+  if (!root || !root.isDirectory()) {
+    if (root) root.close();
+    return;
+  }
+
+  while (_file_count < LOG_LIST_MAX) {
+    File entry = root.openNextFile();
+    if (!entry) break;
+    if (!entry.isDirectory()) {
+      const char* name = entry.name();
+      // entry.name() may include the leading directory; keep the basename only
+      const char* slash = strrchr(name, '/');
+      const char* base = slash ? slash + 1 : name;
+      // Filter for .log files; skip "latest.log" (still being written)
+      const char* dot = strrchr(base, '.');
+      if (dot && strcmp(dot, ".log") == 0 && strcmp(base, "latest.log") != 0) {
+        strncpy(_file_list[_file_count], base, LOG_NAME_MAX - 1);
+        _file_list[_file_count][LOG_NAME_MAX - 1] = '\0';
+        _file_count++;
+      }
+    }
+    entry.close();
+  }
+  root.close();
+
+  // Sort latest first. Dated names (YYYY-MM-DD_HHMM.log) sort lexicographically;
+  // descending strcmp gives newest at the top.
+  for (int i = 1; i < _file_count; i++) {
+    for (int j = i; j > 0 && strcmp(_file_list[j - 1], _file_list[j]) < 0; j--) {
+      char tmp[LOG_NAME_MAX];
+      strncpy(tmp, _file_list[j - 1], LOG_NAME_MAX);
+      strncpy(_file_list[j - 1], _file_list[j], LOG_NAME_MAX);
+      strncpy(_file_list[j], tmp, LOG_NAME_MAX);
+    }
+  }
 }
 
 BaseScreen* LogViewerScreen::handle_input(Controller& controller, const worker_map_t& workers) {
@@ -50,12 +112,6 @@ BaseScreen* LogViewerScreen::handle_input(Controller& controller, const worker_m
   if (strlen(_detail_log_file_name) > 0) {
     // detail view
     if (button1->is_fresh() && button1->get_data().shortPress) {
-      // Back
-      force_next_render();
-      leave_detail();
-      return nullptr;
-    }
-    if (button2->is_fresh() && button2->get_data().shortPress) {
       force_next_render();
       if (!_detail_log_upload_id) {
         // Upload
@@ -63,27 +119,60 @@ BaseScreen* LogViewerScreen::handle_input(Controller& controller, const worker_m
       }
     }
     if (button3->is_fresh() && button3->get_data().shortPress) {
-      return &MenuWindow_i;
+      // Back: detail -> list
+      force_next_render();
+      leave_detail();
+      return nullptr;
     }
-  } else {
-    // not detail view
+  } else if (_current_view == e_log_main_view) {
+    // category selector
     if (button1->is_fresh() && button1->get_data().shortPress) {
       force_next_render();
-      // TODO: selector down
+      _main_selected_index = (_main_selected_index + 1) % MAIN_VIEW_ITEM_COUNT;
       return nullptr;
     }
     if (button2->is_fresh() && button2->get_data().shortPress) {
-      if (_current_view == e_log_main_view) {
-        force_next_render();
-        _current_view = e_log_drive_view;
-      } else {
-        force_next_render();
-        // TODO: enter detail down
-        enter_detail("/drives/2024-11-30_1227.log");
+      force_next_render();
+      switch (_main_selected_index) {
+        case 0: _current_view = e_log_drive_view;   break;
+        case 1: _current_view = e_log_survey_view;  break;
+        case 2: _current_view = e_log_journal_view; break;
       }
+      load_log_list(current_dir());
+      return nullptr;
     }
     if (button3->is_fresh() && button3->get_data().shortPress) {
+      // Back: main -> menu
       return &MenuWindow_i;
+    }
+  } else {
+    // file list view
+    const int total_rows = _file_count + 1; // row 0 reserved historically; we no longer render it
+    if (button1->is_fresh() && button1->get_data().shortPress) {
+      force_next_render();
+      if (_file_count > 0) {
+        _selected_index = (_selected_index + 1) % _file_count;
+      }
+      return nullptr;
+    }
+    if (button2->is_fresh() && button2->get_data().shortPress) {
+      force_next_render();
+      if (_file_count == 0) {
+        return nullptr;
+      }
+      char full_path[LOG_FILENAME_SIZE];
+      snprintf(full_path, LOG_FILENAME_SIZE, "%s/%s",
+               current_dir(), _file_list[_selected_index]);
+      enter_detail(full_path);
+      return nullptr;
+    }
+    if (button3->is_fresh() && button3->get_data().shortPress) {
+      // Back: list -> main
+      force_next_render();
+      _current_view = e_log_main_view;
+      _selected_index = 0;
+      _file_count = 0;
+      return nullptr;
     }
   }
 
@@ -104,12 +193,10 @@ void LogViewerScreen::render(const worker_map_t& workers, const handler_map_t& h
   switch (_current_view) {
     case e_log_main_view:
       return render_main(workers, handlers, force);
-    case e_log_journal_view:
-      return render_journal_log_list(workers, handlers, force);
     case e_log_drive_view:
-      return render_drive_log_list(workers, handlers, force);
     case e_log_survey_view:
-      return render_survey_log_list(workers, handlers, force);
+    case e_log_journal_view:
+      return render_log_list(current_dir(), workers, handlers, force);
     default:
       return;
   }
@@ -118,51 +205,75 @@ void LogViewerScreen::render(const worker_map_t& workers, const handler_map_t& h
 void LogViewerScreen::render_main(const worker_map_t& workers, const handler_map_t& handlers, bool force) {
   drawButton1("Down");
   drawButton2("Select");
-  drawButton3("Menu");
+  drawButton3("Back");
 
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
   M5.Lcd.setCursor(0, 40, &fonts::Font2);
 
-  M5.Lcd.printf(">  Drive logs\n");
-  M5.Lcd.printf("   Survey logs\n");
-  M5.Lcd.printf("   Journal logs\n");
+  const char* labels[MAIN_VIEW_ITEM_COUNT] = {"Drive logs", "Survey logs", "Journal logs"};
+  for (int i = 0; i < MAIN_VIEW_ITEM_COUNT; i++) {
+    M5.Lcd.printf("%s  %s\n", (i == _main_selected_index) ? ">" : " ", labels[i]);
+  }
 }
 
-void LogViewerScreen::render_journal_log_list(const worker_map_t& workers, const handler_map_t& handlers, bool force) {
-}
-
-void LogViewerScreen::render_drive_log_list(const worker_map_t& workers, const handler_map_t& handlers, bool force) {
+void LogViewerScreen::render_log_list(const char* dir, const worker_map_t& workers, const handler_map_t& handlers, bool force) {
   drawButton1("Down");
   drawButton2("Select");
-  drawButton3("Menu");
+  drawButton3("Back");
 
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
   M5.Lcd.setCursor(0, 40, &fonts::Font2);
 
-  M5.Lcd.printf("   Back\n");
-  M5.Lcd.printf(">  2024-11-30_1227.log\n");
-  M5.Lcd.printf("   test2.log\n");
-  M5.Lcd.printf("   test3.log\n");
-}
+  if (_file_count == 0) {
+    M5.Lcd.printf("%s/\n", dir ? dir : "");
+    M5.Lcd.printf("   (no logs)\n");
+    return;
+  }
 
-void LogViewerScreen::render_survey_log_list(const worker_map_t& workers, const handler_map_t& handlers, bool force) {
+  const int total_pages = (_file_count + LOG_LIST_PAGE - 1) / LOG_LIST_PAGE;
+  const int page = _selected_index / LOG_LIST_PAGE;
+  const int start = page * LOG_LIST_PAGE;
+  const int end = (start + LOG_LIST_PAGE < _file_count) ? start + LOG_LIST_PAGE : _file_count;
+  M5.Lcd.printf("%s/  (%d/%d)\n", dir ? dir : "", page + 1, total_pages);
+  for (int i = start; i < end; i++) {
+    M5.Lcd.printf("%s  %s\n",
+                  (i == _selected_index) ? ">" : " ",
+                  _file_list[i]);
+  }
 }
 
 void LogViewerScreen::render_log_detail(const worker_map_t& workers, const handler_map_t& handlers, bool force) {
-  drawButton1("Back");
-  drawButton2("Upload", _detail_log_upload_id || !WiFiWrapper_i.wifi_connected() ? e_button_disabled : e_button_default);
-  drawButton3("Menu");
+  const bool can_upload = !_detail_log_upload_id
+                          && WiFiWrapper_i.wifi_connected()
+                          && _upload_status != e_upload_in_progress;
+  drawButton1("Upload", can_upload ? e_button_default : e_button_disabled);
+  drawButton2("");
+  drawButton3("Back");
 
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
   M5.Lcd.setCursor(0, 40, &fonts::Font2);
 
   M5.Lcd.printf("Log name:      %s\n", _detail_log_file_name);
   M5.Lcd.printf("Timestamp:     %04hu/%02hhu/%02hhu %02hhu:%02hhu\n", _detail_log_timestamp.year, _detail_log_timestamp.month, _detail_log_timestamp.day, _detail_log_timestamp.hour, _detail_log_timestamp.minute);
-  M5.Lcd.printf("Uploaded on:   -\n");
-  M5.Lcd.printf("Upload log id: -\n\n");
-  M5.Lcd.printf("QR code here\n");
+  M5.Lcd.printf("WiFi:          %s\n", WiFiWrapper_i.wifi_connected() ? "connected" : "connecting...");
 
-
+  switch (_upload_status) {
+    case e_upload_idle:
+      M5.Lcd.printf("Status:        ready\n");
+      break;
+    case e_upload_in_progress:
+      M5.Lcd.printf("Status:        uploading...\n");
+      break;
+    case e_upload_success:
+      M5.Lcd.printf("Status:        OK (HTTP %d)\n", _upload_http_code);
+      break;
+    case e_upload_failed:
+      M5.Lcd.printf("Status:        FAILED (HTTP %d)\n", _upload_http_code);
+      break;
+  }
+  if (_detail_log_upload_id) {
+    M5.Lcd.printf("Upload log id: %u\n", _detail_log_upload_id);
+  }
 }
 
 void LogViewerScreen::enter_detail(const char* log_name) {
@@ -184,36 +295,59 @@ void LogViewerScreen::leave_detail() {
   _detail_log_timestamp.clear();
   _detail_upload_timestamp.clear();
   _detail_log_upload_id = 0;
+  _upload_status = e_upload_idle;
+  _upload_http_code = 0;
 }
 
 void LogViewerScreen::enter_screen(Controller& controller) {
   leave_detail();
   _current_view = e_log_main_view;
-  WiFiWrapper_i.connect_wifi(controller.get_settings().get_wifi_ssid(), controller.get_settings().get_wifi_password());
+  _main_selected_index = 0;
+  _selected_index = 0;
+  _file_count = 0;
+  // Use the active WiFi profile (consistent with fixed_mode / api_connector).
+  // first_time=true to force a fresh begin() rather than a passive reconnect,
+  // since other screens may have soft-disconnected the radio.
+  const auto& s = controller.get_settings();
+  WiFiWrapper_i.connect_wifi(s.get_active_wifi_ssid(), s.get_active_wifi_password(), true);
 }
 
 void LogViewerScreen::leave_screen(Controller& controller) {
-  WiFiWrapper_i.disconnect_wifi();
+  // Do not disconnect on leave: api_connector / fixed_mode etc. manage their own
+  // lifecycle and will turn WiFi off when appropriate. Leaving WiFi up reduces
+  // reconnect churn on Core2 where disconnect/reconnect cycles cost seconds.
 }
 
 void LogViewerScreen::upload_detail(const LocalStorage& config) {
+  _upload_status = e_upload_in_progress;
+  _upload_http_code = 0;
+  // Paint a quick "uploading" line directly so the user sees feedback before we block.
+  M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
+  M5.Lcd.setCursor(0, 120, &fonts::Font2);
+  M5.Lcd.printf("Uploading...                ");
+
   File log_file = SDInterface::i().get_file(_detail_log_file_path);
 
   if (!log_file) {
     M5_LOGD("Failed to open log file!");
+    _upload_status = e_upload_failed;
     return;
   }
 
-  char url[100];
-  sprintf(url, "%s?api_key=%s&", API_LOGFILE_ENDPOINT, config.get_api_key());
+  char url[160];
+  snprintf(url, sizeof(url), "%s?api_key=%s", API_LOGFILE_ENDPOINT, config.get_api_key());
 
   ChunkedHTTPClient http;
-  WiFiClient client;
+  WiFiClientSecure client;
+  // TODO: pin Safecast CA bundle. Using setInsecure() until cert plumbing lands.
+  client.setInsecure();
 
-  // Specify destination for HTTP request
+  // Specify destination for HTTPS request
   if (!http.begin(client, url)) {
     M5_LOGD("Unable to begin URL connection");
     http.end(); // Free resources
+    log_file.close();
+    _upload_status = e_upload_failed;
     return;
   }
 
@@ -224,25 +358,29 @@ void LogViewerScreen::upload_detail(const LocalStorage& config) {
   sprintf(content_type_header, "multipart/form-data; boundary=%s", boundary);
 
   http.setUserAgent(HEADER_API_USER_AGENT);
-  http.addHeader("Host", TTSERVE_HOST);
+  // HTTPClient sets Host: from the URL; do not duplicate it here.
   http.addHeader("Content-Type", content_type_header);
   http.addHeader("Transfer-Encoding", "chunked");
+  http.addHeader("Accept", "application/json");
 
   char chunk_header[16];
-  char chunk_buffer[512];
+  static constexpr size_t CHUNK_BUF_SZ = 1024;
+  char chunk_buffer[CHUNK_BUF_SZ];
   size_t chunk_length;
-
 
   if (http.sendPOSTHeaders()) {
     // 1. Send the opening boundary and metadata for the file part as a chunk
+    // RFC 7578: each part = boundary line, headers, blank line, body, CRLF before next boundary.
     sprintf(chunk_buffer,
             "--%s\r\n"
             "Content-Disposition: form-data; name=\"bgeigie_import[description]\"\r\n"
-            "Uploaded from Zen\r\n\r\n"
+            "\r\n"
+            "Uploaded from Zen\r\n"
             "--%s\r\n"
             "Content-Disposition: form-data; name=\"bgeigie_import[source]\"; filename=\"%s\"\r\n"
-            "Content-Type: text/plain\r\n\r\n",
-            boundary, boundary, "2024-11-30_1227.log");
+            "Content-Type: text/plain\r\n"
+            "\r\n",
+            boundary, boundary, _detail_log_file_name);
 
     // Calculate header length
     chunk_length = strlen(chunk_buffer);
@@ -252,20 +390,30 @@ void LogViewerScreen::upload_detail(const LocalStorage& config) {
     client.print("\r\n");                                   // End of chunk
     M5_LOGD("Header chunk sent (%X):\n%s", chunk_length, chunk_buffer);
 
-    // 2. Stream the file content line by line as chunks
+    // 2. Stream the file content in fixed-size blocks. One TLS record per ~1 KB
+    //    keeps throughput reasonable (vs one record per line). yield() after every
+    //    chunk so we don't starve the WiFi task or trip the task watchdog.
+    const uint32_t total_bytes = log_file.size();
+    uint32_t sent_bytes = 0;
+    uint32_t last_log = 0;
     while (log_file.available()) {
-      chunk_length = log_file.readBytesUntil('\n', chunk_buffer, 511); // Read a line from the file
-      chunk_buffer[chunk_length] = '\n'; // Add the newline character back
-      chunk_buffer[chunk_length + 1] = '\0'; // Null-terminate the buffer
-
-      sprintf(chunk_header, " %X\r\n", chunk_length + 1); // Chunk size in hexadecimal (include '\n')
-      client.print(chunk_header);              // Send chunk size
-      client.print(chunk_buffer);               // Send chunk data
-      client.print("\r\n");                                   // End of chunk
+      int n = log_file.read((uint8_t*)chunk_buffer, CHUNK_BUF_SZ);
+      if (n <= 0) break;
+      sprintf(chunk_header, "%X\r\n", n);
+      client.write((const uint8_t*)chunk_header, strlen(chunk_header));
+      client.write((const uint8_t*)chunk_buffer, n);
+      client.write((const uint8_t*)"\r\n", 2);
+      sent_bytes += n;
+      if (sent_bytes - last_log >= 8192) {
+        M5_LOGD("Upload progress: %u / %u bytes", sent_bytes, total_bytes);
+        last_log = sent_bytes;
+      }
+      yield();
     }
+    M5_LOGD("Upload streaming complete: %u bytes", sent_bytes);
 
-    // 3. Send the closing boundary as a chunk
-    sprintf(chunk_buffer, "--%s--\r\n", boundary);
+    // 3. Send the closing boundary as a chunk (with CRLF prefix to terminate file body)
+    sprintf(chunk_buffer, "\r\n--%s--\r\n", boundary);
     chunk_length = strlen(chunk_buffer);
     sprintf(chunk_header, "%X\r\n", chunk_length); // Chunk size in hexadecimal
     client.print(chunk_header);                              // Send chunk size
@@ -282,14 +430,25 @@ void LogViewerScreen::upload_detail(const LocalStorage& config) {
     String response = http.getString();
     M5_LOGD("POST complete, (code %d) response:\n%s", statusCode, response.c_str());
 
+    _upload_http_code = statusCode;
+    if (statusCode >= 200 && statusCode < 300) {
+      _upload_status = e_upload_success;
+      // Best-effort parse: bgeigie_imports returns {"id":<n>, ...}
+      int id_idx = response.indexOf("\"id\":");
+      if (id_idx >= 0) {
+        _detail_log_upload_id = (uint32_t) strtoul(response.c_str() + id_idx + 5, nullptr, 10);
+      }
+    } else {
+      _upload_status = e_upload_failed;
+    }
+
     WiFiWrapper_i.update_active();
   } else {
     M5_LOGD("Failed to initiate request");
+    _upload_status = e_upload_failed;
   }
 
   http.end(); // Free resources
-
-
   log_file.close(); // Close file
-
+  force_next_render();
 }

--- a/bgeigiezen_firmware/screens/log_viewer.cpp
+++ b/bgeigiezen_firmware/screens/log_viewer.cpp
@@ -56,6 +56,7 @@ const char* LogViewerScreen::current_dir() const {
     case e_log_drive_view:   return DRIVE_LOG_DIRECTORY;
     case e_log_survey_view:  return SURVEY_LOG_DIRECTORY;
     case e_log_journal_view: return JOURNAL_LOG_DIRECTORY;
+    case e_log_flight_view:  return FLIGHT_LOG_DIRECTORY;
     default:                 return nullptr;
   }
 }
@@ -71,36 +72,46 @@ void LogViewerScreen::load_log_list(const char* dir) {
     return;
   }
 
-  while (_file_count < LOG_LIST_MAX) {
+  // Scan the whole directory and keep only the LOG_LIST_MAX newest entries.
+  // Reading just the first LOG_LIST_MAX in directory order would drop the
+  // most recent files when the folder has more than LOG_LIST_MAX logs.
+  // Names are dated (YYYY-MM-DD_HHMM.log) so descending strcmp = newest first.
+  while (true) {
     File entry = root.openNextFile();
     if (!entry) break;
-    if (!entry.isDirectory()) {
-      const char* name = entry.name();
-      // entry.name() may include the leading directory; keep the basename only
-      const char* slash = strrchr(name, '/');
-      const char* base = slash ? slash + 1 : name;
-      // Filter for .log files; skip "latest.log" (still being written)
-      const char* dot = strrchr(base, '.');
-      if (dot && strcmp(dot, ".log") == 0 && strcmp(base, "latest.log") != 0) {
-        strncpy(_file_list[_file_count], base, LOG_NAME_MAX - 1);
-        _file_list[_file_count][LOG_NAME_MAX - 1] = '\0';
+    if (entry.isDirectory()) {
+      entry.close();
+      continue;
+    }
+    const char* name = entry.name();
+    const char* slash = strrchr(name, '/');
+    const char* base = slash ? slash + 1 : name;
+    const char* dot = strrchr(base, '.');
+    if (!dot || strcmp(dot, ".log") != 0 || strcmp(base, "latest.log") == 0) {
+      entry.close();
+      continue;
+    }
+
+    // Insertion sort into _file_list, descending. Find the slot, then shift
+    // older entries right; the oldest falls off when the list is full.
+    int pos = 0;
+    while (pos < _file_count && strcmp(_file_list[pos], base) > 0) {
+      pos++;
+    }
+    if (pos < LOG_LIST_MAX) {
+      int last = (_file_count < LOG_LIST_MAX) ? _file_count : LOG_LIST_MAX - 1;
+      for (int j = last; j > pos; j--) {
+        strncpy(_file_list[j], _file_list[j - 1], LOG_NAME_MAX);
+      }
+      strncpy(_file_list[pos], base, LOG_NAME_MAX - 1);
+      _file_list[pos][LOG_NAME_MAX - 1] = '\0';
+      if (_file_count < LOG_LIST_MAX) {
         _file_count++;
       }
     }
     entry.close();
   }
   root.close();
-
-  // Sort latest first. Dated names (YYYY-MM-DD_HHMM.log) sort lexicographically;
-  // descending strcmp gives newest at the top.
-  for (int i = 1; i < _file_count; i++) {
-    for (int j = i; j > 0 && strcmp(_file_list[j - 1], _file_list[j]) < 0; j--) {
-      char tmp[LOG_NAME_MAX];
-      strncpy(tmp, _file_list[j - 1], LOG_NAME_MAX);
-      strncpy(_file_list[j - 1], _file_list[j], LOG_NAME_MAX);
-      strncpy(_file_list[j], tmp, LOG_NAME_MAX);
-    }
-  }
 }
 
 BaseScreen* LogViewerScreen::handle_input(Controller& controller, const worker_map_t& workers) {
@@ -125,29 +136,29 @@ BaseScreen* LogViewerScreen::handle_input(Controller& controller, const worker_m
       return nullptr;
     }
   } else if (_current_view == e_log_main_view) {
-    // category selector
+    // category selector: B1=Down, B2=Back, B3=Select
     if (button1->is_fresh() && button1->get_data().shortPress) {
       force_next_render();
       _main_selected_index = (_main_selected_index + 1) % MAIN_VIEW_ITEM_COUNT;
       return nullptr;
     }
     if (button2->is_fresh() && button2->get_data().shortPress) {
+      // Back: main -> menu
+      return &MenuWindow_i;
+    }
+    if (button3->is_fresh() && button3->get_data().shortPress) {
       force_next_render();
       switch (_main_selected_index) {
         case 0: _current_view = e_log_drive_view;   break;
         case 1: _current_view = e_log_survey_view;  break;
-        case 2: _current_view = e_log_journal_view; break;
+        case 2: _current_view = e_log_flight_view;  break;
+        case 3: _current_view = e_log_journal_view; break;
       }
       load_log_list(current_dir());
       return nullptr;
     }
-    if (button3->is_fresh() && button3->get_data().shortPress) {
-      // Back: main -> menu
-      return &MenuWindow_i;
-    }
   } else {
-    // file list view
-    const int total_rows = _file_count + 1; // row 0 reserved historically; we no longer render it
+    // file list view: B1=Down, B2=Back, B3=Select
     if (button1->is_fresh() && button1->get_data().shortPress) {
       force_next_render();
       if (_file_count > 0) {
@@ -156,6 +167,14 @@ BaseScreen* LogViewerScreen::handle_input(Controller& controller, const worker_m
       return nullptr;
     }
     if (button2->is_fresh() && button2->get_data().shortPress) {
+      // Back: list -> main
+      force_next_render();
+      _current_view = e_log_main_view;
+      _selected_index = 0;
+      _file_count = 0;
+      return nullptr;
+    }
+    if (button3->is_fresh() && button3->get_data().shortPress) {
       force_next_render();
       if (_file_count == 0) {
         return nullptr;
@@ -164,14 +183,6 @@ BaseScreen* LogViewerScreen::handle_input(Controller& controller, const worker_m
       snprintf(full_path, LOG_FILENAME_SIZE, "%s/%s",
                current_dir(), _file_list[_selected_index]);
       enter_detail(full_path);
-      return nullptr;
-    }
-    if (button3->is_fresh() && button3->get_data().shortPress) {
-      // Back: list -> main
-      force_next_render();
-      _current_view = e_log_main_view;
-      _selected_index = 0;
-      _file_count = 0;
       return nullptr;
     }
   }
@@ -204,13 +215,13 @@ void LogViewerScreen::render(const worker_map_t& workers, const handler_map_t& h
 
 void LogViewerScreen::render_main(const worker_map_t& workers, const handler_map_t& handlers, bool force) {
   drawButton1("Down");
-  drawButton2("Select");
-  drawButton3("Back");
+  drawButton2("Back");
+  drawButton3("Select");
 
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
   M5.Lcd.setCursor(0, 40, &fonts::Font2);
 
-  const char* labels[MAIN_VIEW_ITEM_COUNT] = {"Drive logs", "Survey logs", "Journal logs"};
+  const char* labels[MAIN_VIEW_ITEM_COUNT] = {"Drive logs", "Survey logs", "Flight logs", "Journal logs"};
   for (int i = 0; i < MAIN_VIEW_ITEM_COUNT; i++) {
     M5.Lcd.printf("%s  %s\n", (i == _main_selected_index) ? ">" : " ", labels[i]);
   }
@@ -218,8 +229,8 @@ void LogViewerScreen::render_main(const worker_map_t& workers, const handler_map
 
 void LogViewerScreen::render_log_list(const char* dir, const worker_map_t& workers, const handler_map_t& handlers, bool force) {
   drawButton1("Down");
-  drawButton2("Select");
-  drawButton3("Back");
+  drawButton2("Back");
+  drawButton3("Select");
 
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
   M5.Lcd.setCursor(0, 40, &fonts::Font2);
@@ -321,10 +332,22 @@ void LogViewerScreen::leave_screen(Controller& controller) {
 void LogViewerScreen::upload_detail(const LocalStorage& config) {
   _upload_status = e_upload_in_progress;
   _upload_http_code = 0;
-  // Paint a quick "uploading" line directly so the user sees feedback before we block.
+  // Repaint the Status line in place so the user sees feedback before we block.
+  // GFXScreen::loop() draws every frame inside setRotation(3)..setRotation(1) and
+  // leaves the LCD at rotation 1 between ticks. We're called from handle_input,
+  // outside that envelope, so we must re-establish rotation 3 or the text renders
+  // 180-degrees flipped relative to the rest of the screen.
+  // Status line is the 4th Font2 row of render_log_detail (y=40 + 16*3 = 88);
+  // clear it first so leftover glyphs from "ready" don't overlap "uploading...".
+  M5.Lcd.startWrite();
+  M5.Lcd.setRotation(3);
+  M5.Lcd.fillRect(0, 88, M5.Lcd.width(), 16, LCD_COLOR_BACKGROUND);
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
-  M5.Lcd.setCursor(0, 120, &fonts::Font2);
-  M5.Lcd.printf("Uploading...                ");
+  M5.Lcd.setCursor(0, 88, &fonts::Font2);
+  M5.Lcd.printf("Status:        uploading...");
+  M5.Lcd.setRotation(1);
+  M5.Lcd.display();
+  M5.Lcd.endWrite();
 
   File log_file = SDInterface::i().get_file(_detail_log_file_path);
 

--- a/bgeigiezen_firmware/screens/log_viewer.h
+++ b/bgeigiezen_firmware/screens/log_viewer.h
@@ -19,6 +19,7 @@ class LogViewerScreen : public BaseScreen {
     e_log_journal_view,
     e_log_drive_view,
     e_log_survey_view,
+    e_log_flight_view,
   };
 
   enum UploadStatus {
@@ -58,7 +59,7 @@ class LogViewerScreen : public BaseScreen {
   static constexpr int LOG_LIST_MAX = 64;
   static constexpr int LOG_NAME_MAX = 40; // basename only, e.g. "2025-10-12_0032.log"
   static constexpr int LOG_LIST_PAGE = 6; // visible rows per page
-  static constexpr int MAIN_VIEW_ITEM_COUNT = 3; // Drive / Survey / Journal
+  static constexpr int MAIN_VIEW_ITEM_COUNT = 4; // Drive / Survey / Journal / Flight
 
   void load_log_list(const char* dir);
   const char* current_dir() const;

--- a/bgeigiezen_firmware/screens/log_viewer.h
+++ b/bgeigiezen_firmware/screens/log_viewer.h
@@ -21,6 +21,13 @@ class LogViewerScreen : public BaseScreen {
     e_log_survey_view,
   };
 
+  enum UploadStatus {
+    e_upload_idle,
+    e_upload_in_progress,
+    e_upload_success,
+    e_upload_failed,
+  };
+
   struct Timestamp {
     uint16_t year = 0;
     uint8_t month = 0;
@@ -42,12 +49,19 @@ class LogViewerScreen : public BaseScreen {
 
   void render(const worker_map_t& workers, const handler_map_t& handlers, bool force) override;
   void render_main(const worker_map_t& workers, const handler_map_t& handlers, bool force);
-  void render_journal_log_list(const worker_map_t& workers, const handler_map_t& handlers, bool force);
-  void render_drive_log_list(const worker_map_t& workers, const handler_map_t& handlers, bool force);
-  void render_survey_log_list(const worker_map_t& workers, const handler_map_t& handlers, bool force);
+  void render_log_list(const char* dir, const worker_map_t& workers, const handler_map_t& handlers, bool force);
   void render_log_detail(const worker_map_t& workers, const handler_map_t& handlers, bool force);
 
   void upload_detail(const LocalStorage& config);
+
+  // List view helpers
+  static constexpr int LOG_LIST_MAX = 64;
+  static constexpr int LOG_NAME_MAX = 40; // basename only, e.g. "2025-10-12_0032.log"
+  static constexpr int LOG_LIST_PAGE = 6; // visible rows per page
+  static constexpr int MAIN_VIEW_ITEM_COUNT = 3; // Drive / Survey / Journal
+
+  void load_log_list(const char* dir);
+  const char* current_dir() const;
 
   LogView _current_view;
   char _detail_log_file_path[LOG_FILENAME_SIZE];
@@ -56,6 +70,14 @@ class LogViewerScreen : public BaseScreen {
   Timestamp _detail_upload_timestamp;
   uint32_t _detail_log_upload_id;
 
+  // Index 0 = "Back" pseudo-row, 1..N = real files
+  char _file_list[LOG_LIST_MAX][LOG_NAME_MAX];
+  int _file_count;
+  int _selected_index;
+  int _main_selected_index;
+
+  UploadStatus _upload_status;
+  int _upload_http_code;
 };
 
 extern LogViewerScreen LogViewerScreen_i;

--- a/bgeigiezen_firmware/screens/menu_window.cpp
+++ b/bgeigiezen_firmware/screens/menu_window.cpp
@@ -16,7 +16,7 @@ const MenuWindow::MenuItem MAIN_MENU_ITEMS[MAIN_MENU_MAX] = {
     {.title="Real Time mode", .tooltip="Real-time upload to API", .enabled=true, .screen=&FixedModeScreen_i},
     {.title="Cosmic mode", .tooltip="Log data with optimized power settings", .enabled=true, .screen=&FlightModeScreen_i},
     {.title="Satellite view", .tooltip="A 2d constellation map for viewing satellites", .enabled=true, .screen=&SatelliteViewScreen_i},
-    {.title="Log viewer", .tooltip="Log viewer (in progress)", .enabled=false, .screen=&LogViewerScreen_i},
+    {.title="Log viewer", .tooltip="View and upload SD log files over WiFi", .enabled=true, .screen=&LogViewerScreen_i},
     {.title="Settings", .tooltip="Configure your device. Debug info and device information are under Settings > Utilities.", .enabled=true, .screen=&ConfigModeScreen_i},
     {.title="USB File Transfer", .tooltip="Transfer SD card files via USB-C connection", .enabled=true, .screen=&USBTransferScreen_i}
 };

--- a/bgeigiezen_firmware/user_config.h
+++ b/bgeigiezen_firmware/user_config.h
@@ -105,7 +105,7 @@ constexpr char SCREENSAVER_TEXT[] = VERSION_STRING;
 #define TTSERVE_HOST "tt.safecast.org"
 #define API_HOST "api.safecast.org"
 #define TTSERVE_MEASUREMENTS_ENDPOINT "http://" TTSERVE_HOST "/measurements.json"
-#define API_LOGFILE_ENDPOINT "http://" API_HOST "/bgeigie_imports.json"
+#define API_LOGFILE_ENDPOINT "https://" API_HOST "/bgeigie_imports.json"
 #define HEADER_API_USER_AGENT "bGeigieZen/" VERSION_NUMBER
 
 /** Access point settings **/

--- a/bgeigiezen_firmware/user_config.h
+++ b/bgeigiezen_firmware/user_config.h
@@ -74,6 +74,7 @@ constexpr uint32_t SETUP_DEFAULT_ALERT_LEVEL = 100;
 constexpr char JOURNAL_LOG_DIRECTORY[] = "/journals";
 constexpr char DRIVE_LOG_DIRECTORY[] = "/drives";
 constexpr char SURVEY_LOG_DIRECTORY[] = "/surveys";
+constexpr char FLIGHT_LOG_DIRECTORY[] = "/flight";
 constexpr char DEBUG_LOG_DIRECTORY[] = "/debug";
 constexpr char LOG_HEADER_LINE1[] = "# NEW LOG";
 constexpr char LOG_HEADER_LINE2[] = "# format=";

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ build_type = release
 build_flags =
 	-D MAJOR_VERSION=3
 	-D MINOR_VERSION=4
-	-D PATCH_VERSION=0
+	-D PATCH_VERSION=1
 	-D VERSION_BETA=1  ; Mark as beta version
 	-Wno-deprecated-declarations
 lib_deps =


### PR DESCRIPTION
## Summary
- New **SD log upload to Safecast API over WiFi** (carried over from prior commit on this branch).
- Log viewer UX polish: Flight logs category added, Journal moved to the bottom, B2/B3 swapped (Back left of Select) on the category and file list screens for consistency.
- File list now scans the whole directory and keeps only the newest 64 entries via insertion sort, so the newest files always appear at the top when a folder has > 64 logs.
- Upload status repaint fix: `upload_detail` runs outside `GFXScreen::loop()`'s `setRotation(3)..setRotation(1)` envelope, so the in-progress paint was 180-flipped and mis-positioned. Now wrapped in the same `startWrite/setRotation/display/endWrite` envelope and targets the actual `Status:` line at y=88.
- Version bumped to **v3.4.1**.

## Test plan
- [ ] Boot screen shows v3.4.1
- [ ] Log viewer → category list shows Drive / Survey / Flight / Journal in that order; B2=Back, B3=Select
- [ ] In a folder with > 64 logs, the newest filenames appear at the top
- [ ] On the file list, B2=Back returns to the category list, B3=Select opens the detail
- [ ] Upload over WiFi: `Status: uploading...` appears at the same place and orientation as `Status: ready` (no upside-down / mis-placed text)
- [ ] On success, `Status: OK (HTTP 200)` and the upload id are shown