### PR TITLE
fix: disable USB File Transfer menu entry until ready

### DIFF
--- a/bgeigiezen_firmware/screens/menu_window.cpp
+++ b/bgeigiezen_firmware/screens/menu_window.cpp
@@ -18,7 +18,7 @@ const MenuWindow::MenuItem MAIN_MENU_ITEMS[MAIN_MENU_MAX] = {
     {.title="Satellite view", .tooltip="A 2d constellation map for viewing satellites", .enabled=true, .screen=&SatelliteViewScreen_i},
     {.title="Log viewer", .tooltip="View and upload SD log files over WiFi", .enabled=true, .screen=&LogViewerScreen_i},
     {.title="Settings", .tooltip="Configure your device. Debug info and device information are under Settings > Utilities.", .enabled=true, .screen=&ConfigModeScreen_i},
-    {.title="USB File Transfer", .tooltip="Transfer SD card files via USB-C connection", .enabled=true, .screen=&USBTransferScreen_i}
+    {.title="USB File Transfer", .tooltip="Coming soon: transfer SD files via USB-C. Currently disabled while under development.", .enabled=false, .screen=&USBTransferScreen_i}
 };
 
 MenuWindow MenuWindow_i;


### PR DESCRIPTION
## Summary
Greys out the **USB File Transfer** entry in the main menu and disables selection. The screen behind it is still under development (the simulated MSC stub doesn't actually expose the SD card to a host), so showing it as selectable invited users to start a flow that does not yet work. Tooltip updated to explain the WIP state.

## Test plan
- [ ] Open main menu, navigate to "USB File Transfer"
- [ ] Confirm entry renders greyed out (LCD_COLOR_INACTIVE)
- [ ] Confirm Enter button is disabled when the entry is highlighted
- [ ] Confirm tooltip reads "Coming soon: transfer SD files via USB-C. Currently disabled while under development."

🤖 Generated with [Claude Code](https://claude.com/claude-code)