### PR TITLE
fix: WiFi auto-reconnect after disconnect (v3.4.2)

### DIFF
--- a/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
+++ b/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
@@ -1,0 +1,44 @@
+# WiFi reconnect fix
+
+## Problem
+
+The WiFi icon correctly shows red when disconnected, but the device would
+never reconnect on its own. Root causes:
+
+1. The only code path that could call `WiFi.reconnect()`/`WiFi.begin()` was
+   `ApiConnector::handle_produced_work()`, which is gated behind fresh/valid
+   GPS+GM sensor data and a send-frequency timer. If sensor data wasn't
+   flowing, reconnection was never attempted.
+2. No `WiFi.onEvent()` handler existed, so a disconnect was only ever
+   noticed the next time that narrow polling path happened to run.
+3. `connect_wifi()` fired `WiFi.reconnect()`/`WiFi.begin()` then did a single
+   `delay(100)` and gave up — not enough time for the radio to actually
+   reassociate before the attempt was judged failed.
+
+## Fixes
+
+- **`utils/wifi_connection.{h,cpp}`**: added `WiFiWrapper::register_events()`
+  which registers a `WiFi.onEvent()` callback for
+  `ARDUINO_EVENT_WIFI_STA_DISCONNECTED`, flagging the drop immediately
+  (`flag_disconnect_event()` / `consume_disconnect_event()`). Replaced the
+  single `delay(100)` after `WiFi.reconnect()`/`WiFi.begin()` with
+  `wait_for_connection(3000)`, a bounded poll loop that returns as soon as
+  `WL_CONNECTED` is reached (or times out after 3s).
+
+- **`handlers/api_connector.{h,cpp}`**: added `ApiConnector::maintain_connection()`,
+  called every `loop()` iteration regardless of sensor data state. It skips
+  only when no device ID is configured or the AP config screen is active,
+  consumes any pending disconnect event to skip the backoff, and otherwise
+  calls the existing `activate(true)` (10s backoff) to retry.
+
+- **`main.cpp`**: registers the WiFi event handler in `setup()` and calls
+  `api_connector.maintain_connection()` at the top of `loop()`, so
+  reconnection is no longer starved by GPS/GM data gating.
+
+## Net effect
+
+- A dropped link is detected immediately via the event handler.
+- Reconnection is retried periodically in the background, independent of
+  sensor data freshness.
+- Each reconnect attempt gets a real bounded window to succeed instead of
+  a single 100ms check.

--- a/bgeigiezen_firmware/handlers/api_connector.cpp
+++ b/bgeigiezen_firmware/handlers/api_connector.cpp
@@ -6,7 +6,7 @@
 // subtracting 1 seconds so data is sent more often than not.
 #define SEND_FREQUENCY(last_send, sec) ((last_send) == 0 || (millis() - (last_send)) > (((sec) * 1000) - 500))
 
-ApiConnector::ApiConnector(LocalStorage& config) : Handler(), _http_client(), _config(config), _payload(""), _post_count(0), _last_post(0) {
+ApiConnector::ApiConnector(LocalStorage& config) : Handler(), _http_client(), _config(config), _payload(""), _post_count(0), _last_post(0), _last_retry(0) {
 }
 
 bool ApiConnector::time_to_send(bool in_fixed_range, bool alert) const {
@@ -17,18 +17,34 @@ bool ApiConnector::time_to_send(bool in_fixed_range, bool alert) const {
 }
 
 bool ApiConnector::activate(bool retry) {
-  static uint32_t last_try = 0;
   if (WiFiWrapper_i.wifi_connected()) {
     return true;
   }
-  if (retry && millis() - last_try < RETRY_TIMEOUT) {
+  if (retry && millis() - _last_retry < RETRY_TIMEOUT) {
     return false;
   }
-  last_try = millis();
+  _last_retry = millis();
 
   WiFiWrapper_i.connect_wifi(_config.get_active_wifi_ssid(), _config.get_active_wifi_password(), !retry);
 
   return WiFi.isConnected();
+}
+
+void ApiConnector::maintain_connection() {
+  if (!_config.get_fixed_device_id()) {
+    // No valid device id configured, nothing to upload, leave wifi alone
+    return;
+  }
+  if (WiFiWrapper_i.ap_server_up()) {
+    // User is on the AP config screen, don't fight it
+    return;
+  }
+  if (WiFiWrapper_i.consume_disconnect_event()) {
+    // A disconnect event fired: skip the backoff and retry now
+    M5_LOGD("WiFi connector: disconnect event detected, retrying now");
+    _last_retry = 0;
+  }
+  activate(true);
 }
 
 void ApiConnector::deactivate() {

--- a/bgeigiezen_firmware/handlers/api_connector.h
+++ b/bgeigiezen_firmware/handlers/api_connector.h
@@ -35,6 +35,13 @@ class ApiConnector : public Handler {
 
   uint32_t get_post_count() const;
 
+  /**
+   * Called every loop iteration (independent of sensor data freshness) to
+   * keep the WiFi link alive: reacts to disconnect events immediately and
+   * otherwise retries on the normal backoff.
+   */
+  void maintain_connection();
+
  protected:
 
   /**
@@ -70,6 +77,7 @@ class ApiConnector : public Handler {
   char _payload[200];
   uint32_t _post_count;
   uint32_t _last_post;
+  uint32_t _last_retry;
 };
 
 #endif //BGEIGIEZEN_APICONNECTOR_H_

--- a/bgeigiezen_firmware/main.cpp
+++ b/bgeigiezen_firmware/main.cpp
@@ -170,6 +170,9 @@ void setup() {
   M5_LOGD("Register supervisors...");
   controller.register_supervisor(gfx_screen);
 
+  M5_LOGD("Register WiFi event handlers...");
+  WiFiWrapper_i.register_events();
+
   M5_LOGD("Start default workers...");
   controller.start_default_workers();
 
@@ -269,6 +272,10 @@ void loop() {
       button_a_long_press_detected = false;
     }
   }
+
+  // Keep WiFi alive independent of sensor data freshness/validity gating,
+  // which otherwise starves ApiConnector::activate() of any chance to run.
+  api_connector.maintain_connection();
 
   controller.run();
 }

--- a/bgeigiezen_firmware/utils/wifi_connection.cpp
+++ b/bgeigiezen_firmware/utils/wifi_connection.cpp
@@ -9,8 +9,41 @@
 
 WiFiWrapper WiFiWrapper_i;
 
+// Bounded wait for WiFi.status() to reach WL_CONNECTED after begin()/reconnect(),
+// instead of a single delay(100) + give-up.
+static bool wait_for_connection(uint32_t timeout_ms) {
+  uint32_t start = millis();
+  while (millis() - start < timeout_ms) {
+    if (WiFi.status() == WL_CONNECTED) {
+      return true;
+    }
+    delay(100);
+  }
+  return WiFi.status() == WL_CONNECTED;
+}
 
-WiFiWrapper::WiFiWrapper(): _last_activity(0), _hostname("") {
+static void on_wifi_event(WiFiEvent_t event) {
+  if (event == ARDUINO_EVENT_WIFI_STA_DISCONNECTED) {
+    M5_LOGD("WiFi connector: STA disconnected event received");
+    WiFiWrapper_i.flag_disconnect_event();
+  }
+}
+
+WiFiWrapper::WiFiWrapper(): _last_activity(0), _hostname(""), _disconnect_event(false) {
+}
+
+void WiFiWrapper::register_events() {
+  WiFi.onEvent(on_wifi_event);
+}
+
+void WiFiWrapper::flag_disconnect_event() {
+  _disconnect_event = true;
+}
+
+bool WiFiWrapper::consume_disconnect_event() {
+  bool fired = _disconnect_event;
+  _disconnect_event = false;
+  return fired;
 }
 
 
@@ -27,7 +60,7 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
         delay(50);
         #endif
         WiFi.reconnect();
-        delay(100);
+        wait_for_connection(3000);
         update_active();
         return wifi_connected();
       }
@@ -40,7 +73,7 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       delay(50);
       #endif
       WiFi.reconnect();
-      delay(100);
+      wait_for_connection(3000);
       update_active();
       return wifi_connected();
     default:
@@ -79,7 +112,7 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       }
       #endif
       password ? WiFi.begin(ssid, password) : WiFi.begin(ssid);
-      delay(100);
+      wait_for_connection(3000);
       update_active();
       return wifi_connected();
   }

--- a/bgeigiezen_firmware/utils/wifi_connection.h
+++ b/bgeigiezen_firmware/utils/wifi_connection.h
@@ -55,9 +55,26 @@ class WiFiWrapper {
   void update_active();
   bool was_active();
 
+  /**
+   * Register the WiFi station disconnect event handler, so that a dropped
+   * link can be detected immediately instead of waiting for the next poll.
+   */
+  void register_events();
+
+  /**
+   * Returns true (once) if a STA disconnect event fired since the last call.
+   */
+  bool consume_disconnect_event();
+
+  /**
+   * Marks that a STA disconnect event fired. Called from the WiFi event callback.
+   */
+  void flag_disconnect_event();
+
  private:
   char _hostname[20];
   uint32_t _last_activity;
+  bool _disconnect_event;
 };
 
 extern WiFiWrapper WiFiWrapper_i;

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ build_type = release
 build_flags =
 	-D MAJOR_VERSION=3
 	-D MINOR_VERSION=4
-	-D PATCH_VERSION=1
+	-D PATCH_VERSION=2
 	-D VERSION_BETA=1  ; Mark as beta version
 	-Wno-deprecated-declarations
 lib_deps =


### PR DESCRIPTION
## Summary
- Add a `WiFi.onEvent()` disconnect handler so a dropped STA link is detected immediately instead of waiting on sensor-data polling.
- Add `ApiConnector::maintain_connection()`, called every `loop()` iteration independent of GPS/GM data freshness, so reconnection is no longer starved when sensor data isn't flowing.
- Replace the single `delay(100)` after `WiFi.reconnect()`/`WiFi.begin()` with a bounded `wait_for_connection()` poll loop so attempts get a real chance to succeed.
- Bump version to 3.4.2.

See `bgeigiezen_firmware/docs/wifi_reconnect_fix.md` for details.

## Test plan
- [x] Builds successfully for `m5stack-cores3-unified`
- [x] Builds successfully for `m5stack-core2-unified`
- [ ] On-device test: force a WiFi disconnect and confirm the icon returns to green without a manual reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)