### PR TITLE
fix: Core2 touch/button freeze from background WiFi reconnect (v3.4.3)

### DIFF
--- a/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
+++ b/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
@@ -42,3 +42,23 @@ never reconnect on its own. Root causes:
   sensor data freshness.
 - Each reconnect attempt gets a real bounded window to succeed instead of
   a single 100ms check.
+
+## Follow-up fix (v3.4.3): Core2 touch/button freeze
+
+`maintain_connection()` running every `loop()` iteration meant the blocking
+3s `wait_for_connection()` verify-loop (added above) could now fire from the
+background path too. On Core2, `connect_wifi()` also does extra
+`esp_wifi_stop()/start()` housekeeping with hard `delay()`s, so a failed
+reconnect attempt (e.g. real device ID configured but no/wrong WiFi
+credentials) froze `loop()` for ~3.3-3.8s every 10s — long enough that
+`M5.update()` (which polls touch) never got called between touches, making
+menu buttons on Core2 appear unresponsive. CoreS3 has no equivalent
+Core2-only delays and wasn't affected.
+
+Fix: `WiFiWrapper::connect_wifi()` gained a `wait_for_result` parameter.
+`maintain_connection()` (the background/automatic path) now passes `false`
+— it kicks off `WiFi.begin()`/`WiFi.reconnect()` and returns immediately
+without blocking `loop()`, relying on the next periodic call to observe
+whether the connection succeeded. The WiFi settings screen (user-initiated,
+where blocking briefly for feedback is expected) keeps `wait_for_result`
+defaulted to `true`.

--- a/bgeigiezen_firmware/handlers/api_connector.cpp
+++ b/bgeigiezen_firmware/handlers/api_connector.cpp
@@ -31,6 +31,9 @@ bool ApiConnector::activate(bool retry) {
 }
 
 void ApiConnector::maintain_connection() {
+  if (WiFiWrapper_i.wifi_connected()) {
+    return;
+  }
   if (!_config.get_fixed_device_id()) {
     // No valid device id configured, nothing to upload, leave wifi alone
     return;
@@ -44,7 +47,15 @@ void ApiConnector::maintain_connection() {
     M5_LOGD("WiFi connector: disconnect event detected, retrying now");
     _last_retry = 0;
   }
-  activate(true);
+  if (millis() - _last_retry < RETRY_TIMEOUT) {
+    return;
+  }
+  _last_retry = millis();
+
+  // Non-blocking: kick off the attempt and let the next call(s) observe the
+  // result. Never wait here — this runs every loop() iteration and must not
+  // stall touch/button polling (M5.update()).
+  WiFiWrapper_i.connect_wifi(_config.get_active_wifi_ssid(), _config.get_active_wifi_password(), false, false);
 }
 
 void ApiConnector::deactivate() {

--- a/bgeigiezen_firmware/utils/wifi_connection.cpp
+++ b/bgeigiezen_firmware/utils/wifi_connection.cpp
@@ -47,7 +47,7 @@ bool WiFiWrapper::consume_disconnect_event() {
 }
 
 
-bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool first_time) {
+bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool first_time, bool wait_for_result) {
   switch(WiFi.status()) {
     case WL_CONNECTED:
       return true;
@@ -60,7 +60,9 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
         delay(50);
         #endif
         WiFi.reconnect();
-        wait_for_connection(3000);
+        if (wait_for_result) {
+          wait_for_connection(3000);
+        }
         update_active();
         return wifi_connected();
       }
@@ -73,7 +75,9 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       delay(50);
       #endif
       WiFi.reconnect();
-      wait_for_connection(3000);
+      if (wait_for_result) {
+        wait_for_connection(3000);
+      }
       update_active();
       return wifi_connected();
     default:
@@ -112,7 +116,9 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       }
       #endif
       password ? WiFi.begin(ssid, password) : WiFi.begin(ssid);
-      wait_for_connection(3000);
+      if (wait_for_result) {
+        wait_for_connection(3000);
+      }
       update_active();
       return wifi_connected();
   }

--- a/bgeigiezen_firmware/utils/wifi_connection.h
+++ b/bgeigiezen_firmware/utils/wifi_connection.h
@@ -8,9 +8,14 @@ class WiFiWrapper {
    * Connect to wifi endpoint
    * @param ssid
    * @param password
+   * @param wait_for_result if true, block until connected or a bounded
+   *        timeout elapses (safe for user-initiated UI actions); if false,
+   *        kick off the connection attempt and return immediately without
+   *        blocking the caller (required for calls made from the main loop,
+   *        so touch/button polling isn't starved).
    * @return true if connected
    */
-  bool connect_wifi(const char* ssid, const char* password = nullptr, bool first_time = false);
+  bool connect_wifi(const char* ssid, const char* password = nullptr, bool first_time = false, bool wait_for_result = true);
 
   /**
    * disconnect from wifi endpoint

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ build_type = release
 build_flags =
 	-D MAJOR_VERSION=3
 	-D MINOR_VERSION=4
-	-D PATCH_VERSION=2
+	-D PATCH_VERSION=3
 	-D VERSION_BETA=1  ; Mark as beta version
 	-Wno-deprecated-declarations
 lib_deps =


### PR DESCRIPTION
## Summary
- Fixes a regression from 3.4.2: the new background `maintain_connection()` (called every `loop()` iteration) could block for ~3.3-3.8s on Core2 whenever a reconnect attempt failed, starving `M5.update()` and making menu touch buttons appear unresponsive.
- `WiFiWrapper::connect_wifi()` now takes a `wait_for_result` flag. The automatic background path fires the connect attempt without blocking; the WiFi settings screen (user-initiated) keeps the bounded wait for immediate feedback.
- Bump to 3.4.3.

See updated `bgeigiezen_firmware/docs/wifi_reconnect_fix.md` for details.

## Test plan
- [x] Builds successfully for `m5stack-core2-unified`
- [x] Builds successfully for `m5stack-cores3-unified`
- [ ] On-device test on Core2: confirm menu touch buttons stay responsive while WiFi is disconnected/reconnecting

🤖 Generated with [Claude Code](https://claude.com/claude-code)