### PR TITLE
fix: Real-Time mode blank screen on Core2 (v3.4.4)

### DIFF
--- a/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
+++ b/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
@@ -62,3 +62,19 @@ without blocking `loop()`, relying on the next periodic call to observe
 whether the connection succeeded. The WiFi settings screen (user-initiated,
 where blocking briefly for feedback is expected) keeps `wait_for_result`
 defaulted to `true`.
+
+## Follow-up fix (v3.4.4): blank screen entering Real-Time mode on Core2
+
+`GFXScreen`'s screen-switch sequence (`gfx_screen.cpp`) clears the display
+*before* calling the new screen's `enter_screen()`. `FixedModeScreen::enter_screen()`
+(`screens/fixed_mode.cpp`) called `WiFiWrapper_i.connect_wifi(...)` with the
+default `wait_for_result=true`, so on Core2 the same 3s verify-loop (plus
+Core2's `esp_wifi_stop()/start()` delays) ran synchronously right after the
+screen was blanked — a ~3s blank screen every time Real-Time mode was
+entered while WiFi wasn't already connected.
+
+Fix: `FixedModeScreen::enter_screen()` now passes `wait_for_result=false`.
+The Core2-specific WiFi init delays (mode/start housekeeping, needed to
+avoid crashes on an uninitialized radio) still run, but the multi-second
+connect-verify wait is skipped; `maintain_connection()` picks up and
+confirms the connection on a later background pass.

--- a/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
+++ b/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
@@ -78,3 +78,30 @@ The Core2-specific WiFi init delays (mode/start housekeeping, needed to
 avoid crashes on an uninitialized radio) still run, but the multi-second
 connect-verify wait is skipped; `maintain_connection()` picks up and
 confirms the connection on a later background pass.
+
+## Follow-up fix (v3.4.5): screen still blanking + reset switching RT -> Drive mode
+
+The 3.4.4 fix was incomplete: `FixedModeScreen::enter_screen()` calls
+`connect_wifi()` non-blockingly, but immediately after it calls
+`controller.set_handler_active(k_handler_api_reporter, true)`, which (via
+the `Activatable`/`Handler` framework) invokes `ApiConnector::activate()`
+— and *that* also called `connect_wifi()`, without passing
+`wait_for_result=false`. So the blocking 3s verify-loop still ran, just one
+call later in the chain.
+
+Fix: `ApiConnector::activate()` (`handlers/api_connector.cpp`) now always
+passes `wait_for_result=false`. It runs on the main loop/render task both
+from `set_handler_active()` (screen transitions) and the Handler
+framework's own auto-retry, so it must never block.
+
+Separately, switching from Real-Time mode to Drive mode could reset the
+device. `FixedModeScreen::leave_screen()` deactivates the API handler,
+which called `Handler::kill_task()` -> `vTaskDelete()` on the async task
+that runs `ApiConnector::handle_async()` (an in-flight `HTTPClient::POST`).
+Forcibly deleting a FreeRTOS task while it's inside the WiFi/lwIP stack can
+corrupt heap/lock state and crash — consistent with a reset shortly after
+leaving RT mode while a post was in flight.
+
+Fix: `ApiConnector::deactivate()` now waits (bounded to 5s, polling every
+20ms) for the async task to finish naturally before calling `kill_task()`,
+which remains only as a safety net for a genuinely stuck task.

--- a/bgeigiezen_firmware/handlers/api_connector.cpp
+++ b/bgeigiezen_firmware/handlers/api_connector.cpp
@@ -25,7 +25,10 @@ bool ApiConnector::activate(bool retry) {
   }
   _last_retry = millis();
 
-  WiFiWrapper_i.connect_wifi(_config.get_active_wifi_ssid(), _config.get_active_wifi_password(), !retry);
+  // Non-blocking: activate() runs on the main loop/render task (screen
+  // transitions via set_handler_active(), and the Handler framework's own
+  // auto-retry), so it must never stall waiting for a WiFi verify loop.
+  WiFiWrapper_i.connect_wifi(_config.get_active_wifi_ssid(), _config.get_active_wifi_password(), !retry, false);
 
   return WiFi.isConnected();
 }
@@ -59,6 +62,14 @@ void ApiConnector::maintain_connection() {
 }
 
 void ApiConnector::deactivate() {
+  // Don't forcibly vTaskDelete() a task that may be mid-syscall inside the
+  // WiFi/lwIP stack (e.g. an in-flight HTTPClient::POST) — that can corrupt
+  // heap/lock state and reset the device. Give it a bounded window to finish
+  // naturally first; kill_task() below is just a safety net if it's stuck.
+  uint32_t wait_start = millis();
+  while (task_running() && millis() - wait_start < 5000) {
+    delay(20);
+  }
   kill_task();
   WiFiWrapper_i.disconnect_wifi();
 }

--- a/bgeigiezen_firmware/screens/fixed_mode.cpp
+++ b/bgeigiezen_firmware/screens/fixed_mode.cpp
@@ -263,9 +263,12 @@ void FixedModeScreen::render(const worker_map_t& workers, const handler_map_t& h
 
 void FixedModeScreen::enter_screen(Controller& controller) {
   // Initialize WiFi BEFORE activating the handler to ensure WiFi is ready
-  // This prevents crashes on Core2 when WiFi is in an uninitialized state
+  // This prevents crashes on Core2 when WiFi is in an uninitialized state.
+  // wait_for_result=false: don't block screen entry on the multi-second
+  // connect verify loop, the background maintain_connection() will pick up
+  // and confirm the connection on a later pass.
   const auto& settings = controller.get_settings();
-  WiFiWrapper_i.connect_wifi(settings.get_active_wifi_ssid(), settings.get_active_wifi_password());
+  WiFiWrapper_i.connect_wifi(settings.get_active_wifi_ssid(), settings.get_active_wifi_password(), false, false);
 
   controller.set_handler_active(k_handler_api_reporter, true);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ build_type = release
 build_flags =
 	-D MAJOR_VERSION=3
 	-D MINOR_VERSION=4
-	-D PATCH_VERSION=3
+	-D PATCH_VERSION=4
 	-D VERSION_BETA=1  ; Mark as beta version
 	-Wno-deprecated-declarations
 lib_deps =

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ build_type = release
 build_flags =
 	-D MAJOR_VERSION=3
 	-D MINOR_VERSION=4
-	-D PATCH_VERSION=4
+	-D PATCH_VERSION=5
 	-D VERSION_BETA=1  ; Mark as beta version
 	-Wno-deprecated-declarations
 lib_deps =


### PR DESCRIPTION
## Summary
- Fixes ~3s blank screen when switching to Real-Time mode via the menu on Core2.
- `FixedModeScreen::enter_screen()` called `connect_wifi()` with the blocking default right after the display was cleared for the screen switch; on Core2 the connect-verify wait plus extra `esp_wifi_stop()/start()` housekeeping made that ~3s.
- Now passes `wait_for_result=false` — Core2 init delays (needed to avoid crashes on an uninitialized radio) still run, but the multi-second verify wait is skipped; the background `maintain_connection()` (added in 3.4.2/3.4.3) confirms the connection on a later pass.
- Bump to 3.4.4.

## Test plan
- [x] Builds successfully for `m5stack-core2-unified`
- [x] Builds successfully for `m5stack-cores3-unified`
- [ ] On-device test on Core2: switch to Real-Time mode via the menu and confirm the screen no longer blanks for ~3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)