### PR TITLE
fix: don't block main loop for background WiFi reconnect (V3.4.2)

### DIFF
--- a/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
+++ b/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
@@ -42,3 +42,23 @@ never reconnect on its own. Root causes:
   sensor data freshness.
 - Each reconnect attempt gets a real bounded window to succeed instead of
   a single 100ms check.
+
+## Follow-up fix: touch/button freeze from background reconnect
+
+`maintain_connection()` running every `loop()` iteration meant the blocking
+3s `wait_for_connection()` verify-loop (added above) could now fire from the
+background path too. A failed reconnect attempt (e.g. device ID configured
+but no/wrong WiFi credentials) froze `loop()` for up to 3s every 10s (worse
+on Core2, which also runs extra `esp_wifi_stop()/start()` housekeeping with
+hard `delay()`s) — long enough that `M5.update()` (which polls touch/buttons)
+never got called between touches. On Core2 this made menu buttons appear
+unresponsive; on CoreS3 it could make the screen appear un-wakeable from
+screensaver/blanked state, since the wake tap is never sampled.
+
+Fix: `WiFiWrapper::connect_wifi()` gained a `wait_for_result` parameter.
+`maintain_connection()` (the background/automatic path) now passes `false`
+— it kicks off `WiFi.begin()`/`WiFi.reconnect()` and returns immediately
+without blocking `loop()`, relying on the next periodic call to observe
+whether the connection succeeded. The WiFi settings screen (user-initiated,
+where blocking briefly for feedback is expected) keeps `wait_for_result`
+defaulted to `true`.

--- a/bgeigiezen_firmware/handlers/api_connector.cpp
+++ b/bgeigiezen_firmware/handlers/api_connector.cpp
@@ -31,6 +31,9 @@ bool ApiConnector::activate(bool retry) {
 }
 
 void ApiConnector::maintain_connection() {
+  if (WiFiWrapper_i.wifi_connected()) {
+    return;
+  }
   if (!_config.get_fixed_device_id()) {
     // No valid device id configured, nothing to upload, leave wifi alone
     return;
@@ -44,7 +47,17 @@ void ApiConnector::maintain_connection() {
     M5_LOGD("WiFi connector: disconnect event detected, retrying now");
     _last_retry = 0;
   }
-  activate(true);
+  if (millis() - _last_retry < RETRY_TIMEOUT) {
+    return;
+  }
+  _last_retry = millis();
+
+  // Non-blocking: kick off the attempt and let the next call(s) observe the
+  // result. Never wait here — this runs every loop() iteration and must not
+  // stall touch/button polling (M5.update()), which is what freezes the
+  // screen (Core2 menu buttons, CoreS3 screensaver wake) during a failed
+  // background reconnect.
+  WiFiWrapper_i.connect_wifi(_config.get_active_wifi_ssid(), _config.get_active_wifi_password(), false, false);
 }
 
 void ApiConnector::deactivate() {

--- a/bgeigiezen_firmware/utils/wifi_connection.cpp
+++ b/bgeigiezen_firmware/utils/wifi_connection.cpp
@@ -47,7 +47,7 @@ bool WiFiWrapper::consume_disconnect_event() {
 }
 
 
-bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool first_time) {
+bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool first_time, bool wait_for_result) {
   switch(WiFi.status()) {
     case WL_CONNECTED:
       return true;
@@ -60,7 +60,9 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
         delay(50);
         #endif
         WiFi.reconnect();
-        wait_for_connection(3000);
+        if (wait_for_result) {
+          wait_for_connection(3000);
+        }
         update_active();
         return wifi_connected();
       }
@@ -73,7 +75,9 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       delay(50);
       #endif
       WiFi.reconnect();
-      wait_for_connection(3000);
+      if (wait_for_result) {
+        wait_for_connection(3000);
+      }
       update_active();
       return wifi_connected();
     default:
@@ -112,7 +116,9 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       }
       #endif
       password ? WiFi.begin(ssid, password) : WiFi.begin(ssid);
-      wait_for_connection(3000);
+      if (wait_for_result) {
+        wait_for_connection(3000);
+      }
       update_active();
       return wifi_connected();
   }

--- a/bgeigiezen_firmware/utils/wifi_connection.h
+++ b/bgeigiezen_firmware/utils/wifi_connection.h
@@ -8,9 +8,14 @@ class WiFiWrapper {
    * Connect to wifi endpoint
    * @param ssid
    * @param password
+   * @param wait_for_result if true, block until connected or a bounded
+   *        timeout elapses (safe for user-initiated UI actions); if false,
+   *        kick off the connection attempt and return immediately without
+   *        blocking the caller (required for calls made from the main loop,
+   *        so touch/button polling isn't starved).
    * @return true if connected
    */
-  bool connect_wifi(const char* ssid, const char* password = nullptr, bool first_time = false);
+  bool connect_wifi(const char* ssid, const char* password = nullptr, bool first_time = false, bool wait_for_result = true);
 
   /**
    * disconnect from wifi endpoint


### PR DESCRIPTION
## Summary
- `ApiConnector::maintain_connection()` runs every `loop()` and could call the blocking `connect_wifi()` (up to 3s, more on Core2) whenever WiFi was down, starving `M5.update()` and stalling touch/button polling.
- On Core2 this showed as unresponsive menu buttons; on CoreS3 it could make the screen appear un-wakeable from screensaver, since the wake tap was never sampled.
- `connect_wifi()` gains a `wait_for_result` flag; the background reconnect path now fires the attempt and returns immediately instead of blocking `loop()`. User-initiated connects (WiFi settings screen) keep the bounded wait.
- Re-applies PR #90 (merged then reverted); version intentionally stays at 3.4.2.

## Test plan
- [x] `pio run -e m5stack-cores3-unified` — builds successfully
- [x] `pio run -e m5stack-core2-unified` — builds successfully
- [ ] Flash to CoreS3 with a configured device ID + wrong WiFi creds, confirm screensaver wakes on touch during background retries
- [ ] Flash to Core2, confirm menu buttons stay responsive during background retries

🤖 Generated with [Claude Code](https://claude.com/claude-code)