### PR TITLE
fix: update RT mode QR/URL to dashboard.radnote.org

### DIFF
--- a/bgeigiezen_firmware/user_config.h
+++ b/bgeigiezen_firmware/user_config.h
@@ -88,7 +88,7 @@ constexpr uint16_t API_SEND_SECONDS_DELAY = 300; // Posts every 5 minute by defa
 constexpr uint16_t API_SEND_SECONDS_DELAY_ALERT = 5; // Posts every 5 seconds when alerted
 constexpr uint16_t API_SEND_SECONDS_DELAY_ROAMING = 5; // Posts every 5 seconds when roaming
 
-constexpr char FIXED_MODE_GRAFANA_URL[] = "https://tinyurl.com/34yr2tzv?var-device_urn_name=geigiecast-zen:%d&from=now-24h&to=now";
+constexpr char FIXED_MODE_GRAFANA_URL[] = "https://dashboard.radnote.org/d/cdq671mxg2cjka/radnote-overview?var-device=dev:geigiecast-zen:%d&from=now-24h&to=now&orgId=1";
 
 // Other
 constexpr char SCREENSAVER_TEXT[] = VERSION_STRING;


### PR DESCRIPTION
## Summary
- Grafana instance moved from grafana.safecast.jp to dashboard.radnote.org
- Updates `FIXED_MODE_GRAFANA_URL` used for the RT mode QR code and the config web page link

## Test plan
- [x] `pio run -e m5stack-cores3-unified` builds successfully
- [x] Verified on device: QR code now resolves to dashboard.radnote.org with correct device ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)