### PR TITLE
fix: async WiFi connect rewrite — removes blocking wait entirely (v3.4.3)

### DIFF
--- a/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
+++ b/bgeigiezen_firmware/docs/wifi_reconnect_fix.md
@@ -62,3 +62,48 @@ without blocking `loop()`, relying on the next periodic call to observe
 whether the connection succeeded. The WiFi settings screen (user-initiated,
 where blocking briefly for feedback is expected) keeps `wait_for_result`
 defaulted to `true`.
+
+**Superseded by the rewrite below** — the `wait_for_result` flag design was
+abandoned in v3.4.3 because every call site had to remember to opt out of
+blocking, and two were missed (see below).
+
+## Rewrite (v3.4.3): remove the blocking wait entirely
+
+Across three follow-up patches (touch freeze, then RT-mode blank screen,
+twice), the root problem kept resurfacing: `connect_wifi()` could still
+block for up to 3s via `wait_for_connection()`, a `while` loop polling
+`WiFi.status()` every 100ms — not a literal `delay(3000)`, but functionally
+the same for the caller, since it never returns control to `loop()` until
+connected or timed out. Every new call site (`ApiConnector::activate()`,
+`FixedModeScreen::enter_screen()`, `LogViewerScreen::enter_screen()`, the
+WiFi settings screen) had to explicitly opt out via `wait_for_result=false`
+to avoid it, and it was easy to miss one — which is exactly what kept
+happening.
+
+The fix: `connect_wifi()` no longer has a blocking mode at all.
+`wait_for_connection()` and the `wait_for_result` parameter are gone.
+`connect_wifi()` fires `WiFi.begin()`/`WiFi.reconnect()` and returns
+immediately, always — no call site can opt back into blocking, so no call
+site can regress.
+
+The state that the blocking wait used to track (is an attempt in flight,
+has it timed out) moved into `WiFiWrapper` using an `RBD::Timer`
+(`alextaujenis/RBD_Timer`, already a dependency — used the same way for
+GPS fix-age tracking in `gps_connector.h`):
+- `connect_wifi()` calls `_connect_timer.restart()` when it fires an attempt.
+- `WiFiWrapper::connecting()` — true while an attempt is in flight and the
+  8s timeout (`WIFI_CONNECT_TIMEOUT_MS`) hasn't elapsed.
+- `WiFiWrapper::connect_timed_out()` — true once that timeout elapses
+  without connecting.
+
+Callers that used to get synchronous feedback now poll instead. The WiFi
+settings screen's local-network page (`screens/wifi_settings.cpp`) now
+calls `force_next_render()` from `handle_input()` every tick while
+`!wifi_connected()`, so the "Connected: ..." status line updates live as
+the async attempt resolves (showing "Connecting..." then "Yes" or
+"Timed out"), rather than only rendering once on screen entry.
+
+The pre-existing Core2 `esp_wifi_stop()/start()` housekeeping and its
+`delay(50/100/200)` calls (~300-700ms total, guarding against crashes on an
+uninitialized radio) were left alone — those are a separate, much smaller
+cost and not what was causing the multi-second freezes.

--- a/bgeigiezen_firmware/handlers/api_connector.cpp
+++ b/bgeigiezen_firmware/handlers/api_connector.cpp
@@ -52,12 +52,7 @@ void ApiConnector::maintain_connection() {
   }
   _last_retry = millis();
 
-  // Non-blocking: kick off the attempt and let the next call(s) observe the
-  // result. Never wait here — this runs every loop() iteration and must not
-  // stall touch/button polling (M5.update()), which is what freezes the
-  // screen (Core2 menu buttons, CoreS3 screensaver wake) during a failed
-  // background reconnect.
-  WiFiWrapper_i.connect_wifi(_config.get_active_wifi_ssid(), _config.get_active_wifi_password(), false, false);
+  WiFiWrapper_i.connect_wifi(_config.get_active_wifi_ssid(), _config.get_active_wifi_password(), false);
 }
 
 void ApiConnector::deactivate() {

--- a/bgeigiezen_firmware/screens/wifi_settings.cpp
+++ b/bgeigiezen_firmware/screens/wifi_settings.cpp
@@ -59,6 +59,11 @@ void WifiSettingsScreen::leave_screen(Controller& controller) {
 }
 
 BaseScreen* WifiSettingsScreen::handle_input(Controller& controller, const worker_map_t& workers) {
+  if (!menu_open() && _current_page == e_wifi_page_local && !WiFiWrapper_i.wifi_connected()) {
+    // connect_wifi() is async now — keep the "Connected: ..." status live
+    // until the attempt resolves (connects or times out).
+    force_next_render();
+  }
   if (menu_open()) {
     return handle_menu_input(controller, workers, WIFI_MENU, e_wifi_MENU_MAX);
   }
@@ -121,7 +126,10 @@ void WifiSettingsScreen::render_page_local(const worker_map_t& workers, const ha
   M5.Lcd.setTextColor(LCD_COLOR_DEFAULT, LCD_COLOR_BACKGROUND);
   M5.Lcd.printf("Config through local network, connect to\n");
   M5.Lcd.printf("Network:  %s\n", settings->get_wifi_ssid());
-  M5.Lcd.printf("Connected:  %s\n", WiFiWrapper_i.wifi_connected() ? "Yes          " : "Not yet...");
+  const char* status = WiFiWrapper_i.wifi_connected()
+      ? "Yes          "
+      : (WiFiWrapper_i.connect_timed_out() ? "Timed out    " : "Connecting...");
+  M5.Lcd.printf("Connected:  %s\n", status);
 
   M5.Lcd.printf("IP:  %s               \n", WiFiWrapper_i.wifi_connected() ? WiFi.localIP().toString().c_str() : "Waiting for connection... ");
 }

--- a/bgeigiezen_firmware/utils/wifi_connection.cpp
+++ b/bgeigiezen_firmware/utils/wifi_connection.cpp
@@ -9,18 +9,7 @@
 
 WiFiWrapper WiFiWrapper_i;
 
-// Bounded wait for WiFi.status() to reach WL_CONNECTED after begin()/reconnect(),
-// instead of a single delay(100) + give-up.
-static bool wait_for_connection(uint32_t timeout_ms) {
-  uint32_t start = millis();
-  while (millis() - start < timeout_ms) {
-    if (WiFi.status() == WL_CONNECTED) {
-      return true;
-    }
-    delay(100);
-  }
-  return WiFi.status() == WL_CONNECTED;
-}
+#define WIFI_CONNECT_TIMEOUT_MS 8000
 
 static void on_wifi_event(WiFiEvent_t event) {
   if (event == ARDUINO_EVENT_WIFI_STA_DISCONNECTED) {
@@ -29,7 +18,8 @@ static void on_wifi_event(WiFiEvent_t event) {
   }
 }
 
-WiFiWrapper::WiFiWrapper(): _last_activity(0), _hostname(""), _disconnect_event(false) {
+WiFiWrapper::WiFiWrapper(): _last_activity(0), _hostname(""), _disconnect_event(false),
+    _connect_attempt_active(false), _connect_timer(WIFI_CONNECT_TIMEOUT_MS) {
 }
 
 void WiFiWrapper::register_events() {
@@ -47,9 +37,10 @@ bool WiFiWrapper::consume_disconnect_event() {
 }
 
 
-bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool first_time, bool wait_for_result) {
+bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool first_time) {
   switch(WiFi.status()) {
     case WL_CONNECTED:
+      _connect_attempt_active = false;
       return true;
     case WL_CONNECT_FAILED:
       if (first_time) {
@@ -60,9 +51,8 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
         delay(50);
         #endif
         WiFi.reconnect();
-        if (wait_for_result) {
-          wait_for_connection(3000);
-        }
+        _connect_attempt_active = true;
+        _connect_timer.restart();
         update_active();
         return wifi_connected();
       }
@@ -75,9 +65,8 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       delay(50);
       #endif
       WiFi.reconnect();
-      if (wait_for_result) {
-        wait_for_connection(3000);
-      }
+      _connect_attempt_active = true;
+      _connect_timer.restart();
       update_active();
       return wifi_connected();
     default:
@@ -116,12 +105,26 @@ bool WiFiWrapper::connect_wifi(const char* ssid, const char* password, bool firs
       }
       #endif
       password ? WiFi.begin(ssid, password) : WiFi.begin(ssid);
-      if (wait_for_result) {
-        wait_for_connection(3000);
-      }
+      _connect_attempt_active = true;
+      _connect_timer.restart();
       update_active();
       return wifi_connected();
   }
+}
+
+bool WiFiWrapper::connecting() {
+  if (wifi_connected()) {
+    _connect_attempt_active = false;
+    return false;
+  }
+  return _connect_attempt_active && !_connect_timer.isExpired();
+}
+
+bool WiFiWrapper::connect_timed_out() {
+  if (wifi_connected()) {
+    return false;
+  }
+  return _connect_attempt_active && _connect_timer.isExpired();
 }
 
 void WiFiWrapper::disconnect_wifi() {

--- a/bgeigiezen_firmware/utils/wifi_connection.h
+++ b/bgeigiezen_firmware/utils/wifi_connection.h
@@ -1,21 +1,33 @@
 #ifndef BGEIGIEZEN_WIFI_WRAPPER_H_
 #define BGEIGIEZEN_WIFI_WRAPPER_H_
 
+#include <RBD_Timer.h>
+
 class WiFiWrapper {
  public:
   WiFiWrapper();
   /**
-   * Connect to wifi endpoint
+   * Fire a connect attempt (WiFi.begin()/WiFi.reconnect()) and return
+   * immediately — this NEVER blocks waiting for the result. Callers that
+   * need to know the outcome must poll wifi_connected() / connecting() /
+   * connect_timed_out() on later loop() ticks or render passes.
    * @param ssid
    * @param password
-   * @param wait_for_result if true, block until connected or a bounded
-   *        timeout elapses (safe for user-initiated UI actions); if false,
-   *        kick off the connection attempt and return immediately without
-   *        blocking the caller (required for calls made from the main loop,
-   *        so touch/button polling isn't starved).
-   * @return true if connected
+   * @return true only if WiFi was already connected before this call
    */
-  bool connect_wifi(const char* ssid, const char* password = nullptr, bool first_time = false, bool wait_for_result = true);
+  bool connect_wifi(const char* ssid, const char* password = nullptr, bool first_time = false);
+
+  /**
+   * True while a connect attempt fired by connect_wifi() is still in
+   * flight (not yet connected, not yet timed out).
+   */
+  bool connecting();
+
+  /**
+   * True if the most recent connect attempt has been running longer than
+   * the connect timeout without succeeding.
+   */
+  bool connect_timed_out();
 
   /**
    * disconnect from wifi endpoint
@@ -80,6 +92,8 @@ class WiFiWrapper {
   char _hostname[20];
   uint32_t _last_activity;
   bool _disconnect_event;
+  bool _connect_attempt_active;
+  RBD::Timer _connect_timer;
 };
 
 extern WiFiWrapper WiFiWrapper_i;

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,7 +23,7 @@ build_type = release
 build_flags =
 	-D MAJOR_VERSION=3
 	-D MINOR_VERSION=4
-	-D PATCH_VERSION=2
+	-D PATCH_VERSION=3
 	-D VERSION_BETA=1  ; Mark as beta version
 	-Wno-deprecated-declarations
 lib_deps =


### PR DESCRIPTION
## Summary
This replaces the `wait_for_result` opt-out approach (which needed every call site to remember to pass `false`, and missed some, causing repeated regressions) with a proper fix: **`connect_wifi()` can no longer block at all.**

- `WiFiWrapper::connect_wifi()` fires `WiFi.begin()`/`WiFi.reconnect()` and always returns immediately. `wait_for_connection()` and the `wait_for_result` parameter are removed entirely.
- Added `RBD::Timer`-based attempt tracking (`alextaujenis/RBD_Timer`, already a dependency, used the same way for GPS fix-age tracking): `WiFiWrapper::connecting()` and `connect_timed_out()` let callers poll the outcome asynchronously.
- `screens/wifi_settings.cpp`'s local-network page now force-renders each tick while not connected, so its status line updates live ("Connecting..." → "Yes"/"Timed out") since the result is no longer available synchronously on screen entry.
- Left the pre-existing Core2 `esp_wifi_stop()/start()` housekeeping (~300-700ms, crash guard for an uninitialized radio) alone — that's a separate, much smaller cost, not the source of the multi-second freezes.
- Bump to 3.4.3.

This should fix, structurally rather than per-call-site, the Real-Time-mode blank screen (and any other screen entry that touches WiFi) on both Core2 and CoreS3.

## Test plan
- [x] Builds successfully for `m5stack-core2-unified`
- [x] Builds successfully for `m5stack-cores3-unified`
- [ ] **On-device test on Core2 (please test before merge):**
  - [ ] Switch to Real-Time mode via the menu — screen should not blank for ~3s
  - [ ] Switch from Real-Time mode to Drive mode — should not reset
  - [ ] Menu touch buttons stay responsive while WiFi is disconnected/reconnecting
  - [ ] WiFi settings → local network page shows live "Connecting..." → "Yes" status

**Do not merge until confirmed working on hardware.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)